### PR TITLE
Modernize to Rust 2024 + fix correctness defects (v0.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-06-10
+
+Modernization to current idiomatic Rust, dependency updates, and a set of
+correctness fixes. This is a breaking release: the public API has changed.
+
+### Added
+- `D20Error`, a descriptive error enum (`EmptyExpression`, `InvalidTerm`,
+  `MissingOperator`, `ZeroSidedDie`, `DiceCountTooLarge`, `SidesTooLarge`,
+  `ModifierTooLarge`, `InvalidRange`) returned by all fallible functions.
+- Documented, public limits `MAX_DICE`, `MAX_SIDES`, and `MAX_MODIFIER`; values
+  beyond them return a clear error instead of overflowing.
+- `TermResult` enum (`Dice { multiplier, sides, rolls }` / `Modifier(i32)`) with
+  `subtotal()` and `rolls()` accessors, now the element type of `Roll::terms`.
+- `roll_dice_with_rng` and `roll_range_with_rng` for deterministic, seeded rolls
+  with a caller-supplied RNG.
+- `Roll::rolls()`, an explicit iterator of fresh re-rolls that reuses the parsed
+  terms instead of re-parsing.
+- `d6` shorthand (equivalent to `1d6`) and uppercase `D` (e.g. `1D20`).
+- `CHANGELOG.md` (this file).
+
+### Changed
+- **Breaking:** `roll_dice` and `roll_range` now return `Result<_, D20Error>`
+  instead of `Result<_, &str>`.
+- **Breaking:** `Roll.values: Vec<(DieRollTerm, Vec<i8>)>` replaced by
+  `Roll.terms: Vec<TermResult>`; `Roll.total` widened from `i32` to `i64`.
+- **Breaking:** die-roll term fields widened — multiplier `i8` → `i32`, sides
+  `u8` → `u32`, individual die results now `u32`.
+- **Breaking:** the surprising infinite `IntoIterator for Roll` is replaced by
+  the explicit `Roll::rolls()` method.
+- `Roll` now stores the original expression in `drex` (previously a
+  whitespace-stripped copy).
+- Bumped to Rust edition 2024; updated dependencies `rand 0.3 → 0.10` and
+  `regex 0.2 → 1`; the parsing regex is compiled once via `std::sync::LazyLock`.
+- The parser now validates the entire input as a sequence of signed terms rather
+  than scanning for number-shaped substrings.
+
+### Fixed
+- No input can panic anymore. Previously, oversized counts/sides/modifiers
+  (e.g. `128d6`, `1d256`, `+500`), `1d0`, `-128d6`, and `roll_range(_, i32::MAX)`
+  all panicked despite the advertised `Result` API.
+- Whitespace between terms no longer merges them: `2d6 5` is now rejected
+  (`MissingOperator`) rather than silently becoming a single 65-sided die.
+- Expressions containing stray text (e.g. `I have 5 apples`, `2 plus 2 ...`) are
+  now rejected instead of having numbers extracted from them.
+- `d6` is rolled as one six-sided die instead of being misread as the
+  constant `+6`.
+- Uppercase `D` (e.g. `1D20`) now parses correctly instead of panicking.
+
+### Removed
+- **Breaking:** `DieRollTerm` is no longer part of the public API (it is now an
+  internal parse-only type); inspect results through `Roll::terms` /
+  `TermResult` instead.
+
+## [0.1.0] - 2017
+
+Initial release.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ edition = "2024"
 [dependencies]
 rand = "0.10"
 regex = "1"
+thiserror = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "d20"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Dan Nemeth <dan.nemeth@gmail.com>", "Kevin Hoffman <alothien@gmail.com>"]
 description = "A library for rolling dice based on simple expressions"
 license = "MPL-2.0"
@@ -16,3 +16,6 @@ edition = "2024"
 rand = "0.10"
 regex = "1"
 thiserror = "2"
+
+[dev-dependencies]
+proptest = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/d20"
 repository = "https://github.com/pholactery/d20"
 readme = "README.md"
 keywords = ["dice", "roll", "game", "random", "dnd"]
+edition = "2024"
 
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ edition = "2024"
 
 
 [dependencies]
-rand = "0.3"
-regex = "0.2"
+rand = "0.10"
+regex = "1"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,27 @@ however malformed — will ever panic. Counts, sides, and modifiers are supporte
 up to the documented `MAX_DICE` / `MAX_SIDES` / `MAX_MODIFIER` limits; values
 beyond them return a clear error rather than overflowing.
 
+### Inspecting Results
+A `Roll` exposes the per-term breakdown via `terms: Vec<TermResult>`. Each
+`TermResult` is either a `Dice { multiplier, sides, rolls }` recording the
+individual die results, or a `Modifier(i32)` constant — so the data is
+self-describing (modifiers are not faked as single-element rolls):
+
+```rust
+use d20::TermResult;
+
+let r = d20::roll_dice("3d6 + 2").unwrap();
+for term in &r.terms {
+    match term {
+        TermResult::Dice { multiplier, sides, rolls } => {
+            println!("{multiplier}d{sides} rolled {rolls:?} (subtotal {})", term.subtotal());
+        }
+        TermResult::Modifier(n) => println!("modifier {n}"),
+    }
+}
+assert_eq!(r.total, r.terms.iter().map(TermResult::subtotal).sum());
+```
+
 ### Iterating Roll
 A valid `Roll` can be turned into an open-ended iterator via its `rolls()` method, providing successive
 rolls of the given die roll expression.

--- a/README.md
+++ b/README.md
@@ -26,53 +26,61 @@ Roll expressions can have arbitrary length and complexity, and it is perfectly l
 of a roll expression to be negative after applying modifiers.
 
 ## Usage
-```
-extern crate d20;
+```rust
+let r = d20::roll_dice("3d6 + 4").unwrap();
+assert!(r.total > 6);
 
-fn main() {
-    let r = d20::roll_dice("3d6 + 4").unwrap();
-    assert!(r.total > 6);
-    let r = d20::roll_dice("1d1-3").unwrap();
-    assert_eq!(r.total, -2);
+let r = d20::roll_dice("1d1-3").unwrap();
+assert_eq!(r.total, -2);
 
-    let r = d20::roll_dice("roll four chickens and add six ferrets");
-    match r {
-       Ok(_) => assert!(false), // this should NOT be ok, fail
-       Err(_) => assert!(true), // bad expressions produce errors
-   }
-}
+// Malformed expressions return a descriptive error instead of panicking.
+assert!(d20::roll_dice("roll four chickens and add six ferrets").is_err());
 ```
+
+Every failure mode is reported through the `d20::D20Error` enum, and no input —
+however malformed — will ever panic. Counts, sides, and modifiers are supported
+up to the documented `MAX_DICE` / `MAX_SIDES` / `MAX_MODIFIER` limits; values
+beyond them return a clear error rather than overflowing.
+
 ### Iterating Roll
-A valid `Roll` can be converted into an open ended iterator via its `into_iter()` method, providing successive
+A valid `Roll` can be turned into an open-ended iterator via its `rolls()` method, providing successive
 rolls of the given die roll expression.
 
 _Note that it will be necessary to constrain the iterator via `take(n)`._
- 
+
 ```rust
-extern crate d20;
 use d20::*;
 
-fn main() {
-    let raw_stats: Vec<Roll> = d20::roll_dice("3d6").unwrap().into_iter().take(6).collect();
+let raw_stats: Vec<Roll> = d20::roll_dice("3d6").unwrap().rolls().take(6).collect();
 
-    println!("\nCHARACTER STATS:");
-    println!("  STR: {}", raw_stats[0].total);
-    println!("  INT: {}", raw_stats[1].total);
-    println!("  WIS: {}", raw_stats[2].total);
-    println!("  DEX: {}", raw_stats[3].total);
-    println!("  CON: {}", raw_stats[4].total);
-    println!("  CHA: {}", raw_stats[5].total);
-}
- ```
+println!("\nCHARACTER STATS:");
+println!("  STR: {}", raw_stats[0].total);
+println!("  INT: {}", raw_stats[1].total);
+println!("  WIS: {}", raw_stats[2].total);
+println!("  DEX: {}", raw_stats[3].total);
+println!("  CON: {}", raw_stats[4].total);
+println!("  CHA: {}", raw_stats[5].total);
+```
+
+### Deterministic Rolls
+For reproducible results (tests, replays), supply your own RNG via
+`roll_dice_with_rng` / `roll_range_with_rng`:
+
+```rust
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+let mut rng = StdRng::seed_from_u64(42);
+let a = d20::roll_dice_with_rng("3d6", &mut rng).unwrap();
+let b = d20::roll_dice_with_rng("3d6", &mut StdRng::seed_from_u64(42)).unwrap();
+assert_eq!(a, b); // same seed => same roll
+```
 
 ### Range Rolls
 If you are less concerned about dice rolls and require only a random number within a given range, `roll_range()`
 will do just that.
 
 ```rust
-extern crate d20;
-fn main() {
-    let rg = d20::roll_range(1,100).unwrap();
-    assert!(rg >= 1 && rg <= 100);
-}
+let rg = d20::roll_range(1, 100).unwrap();
+assert!((1..=100).contains(&rg));
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,9 +80,69 @@ use regex::Regex;
 static DICE_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"([+-]?\s*\d+[dD]\d+|[+-]?\s*\d+)").unwrap());
 
+/// Maximum number of dice a single term may roll (e.g. the `100` in `100d6`).
+/// Larger counts are rejected with [`D20Error::DiceCountTooLarge`] rather than
+/// panicking or hanging.
+pub const MAX_DICE: u32 = 1_000_000;
 
+/// Maximum number of sides a die may have (e.g. the `20` in `1d20`). Larger
+/// values are rejected with [`D20Error::SidesTooLarge`].
+pub const MAX_SIDES: u32 = 1_000_000;
 
-/// Represents the _results_ of an evaluated die roll expression. 
+/// Maximum absolute value of a numeric modifier (e.g. the `5` in `+5`). Larger
+/// magnitudes are rejected with [`D20Error::ModifierTooLarge`].
+pub const MAX_MODIFIER: u32 = 1_000_000;
+
+/// The error type returned when a roll expression cannot be evaluated.
+///
+/// Every failure mode is reported as a value of this type; the library never
+/// panics on malformed or out-of-range input.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum D20Error {
+    /// The expression contained no recognizable die-roll terms.
+    #[error("invalid die roll expression: no die roll terms found")]
+    EmptyExpression,
+    /// A term could not be parsed (e.g. a number too large to fit a 64-bit integer).
+    #[error("invalid term: '{0}'")]
+    InvalidTerm(String),
+    /// A die was specified with zero sides, which cannot be rolled.
+    #[error("invalid die: a die must have at least one side")]
+    ZeroSidedDie,
+    /// A die-roll term asked for more than [`MAX_DICE`] dice.
+    #[error("dice count {count} exceeds the maximum of {max}")]
+    DiceCountTooLarge {
+        /// The requested number of dice.
+        count: u64,
+        /// The maximum allowed ([`MAX_DICE`]).
+        max: u32,
+    },
+    /// A die was specified with more than [`MAX_SIDES`] sides.
+    #[error("die with {sides} sides exceeds the maximum of {max}")]
+    SidesTooLarge {
+        /// The requested number of sides.
+        sides: u64,
+        /// The maximum allowed ([`MAX_SIDES`]).
+        max: u32,
+    },
+    /// A modifier's magnitude exceeded [`MAX_MODIFIER`].
+    #[error("modifier {modifier} exceeds the maximum magnitude of {max}")]
+    ModifierTooLarge {
+        /// The requested modifier value.
+        modifier: i64,
+        /// The maximum allowed magnitude ([`MAX_MODIFIER`]).
+        max: u32,
+    },
+    /// [`roll_range`] was called with `min` greater than `max`.
+    #[error("invalid range: min ({min}) must be less than or equal to max ({max})")]
+    InvalidRange {
+        /// The supplied lower bound.
+        min: i32,
+        /// The supplied upper bound.
+        max: i32,
+    },
+}
+
+/// Represents the _results_ of an evaluated die roll expression.
 /// 
 /// The `Roll` struct contains the original _die roll expression_ passed to the `roll_dice()`
 /// function.
@@ -101,9 +161,9 @@ pub struct Roll {
     /// A die roll expression conforming to the format specification
     pub drex: String,
     /// The results of evaluating each term in the expression
-    pub values: Vec<(DieRollTerm, Vec<i8>)>,
+    pub values: Vec<(DieRollTerm, Vec<i32>)>,
     /// The net final result of evaluating all terms in the expression
-    pub total: i32,
+    pub total: i64,
 }
 
 
@@ -168,53 +228,90 @@ impl Iterator for RollIterator {
 
 /// Represents an individual term within a die roll expression. Terms can either be numeric
 /// modifiers like `+5` or `-2` or they can be terms indicating die rolls.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DieRollTerm {
     /// Indicates a die roll term to roll `multiplier` dice with `sides` sides.
     DieRoll {
-        /// Number of times to roll the given die
-        multiplier: i8,
-        /// Number of sides on the given die
-        sides: u8,
+        /// Number of times to roll the given die. A negative value subtracts the
+        /// rolled total from the expression. Bounded by [`MAX_DICE`] in magnitude.
+        multiplier: i32,
+        /// Number of sides on the given die. At least 1 and at most [`MAX_SIDES`].
+        sides: u32,
     },
     /// Numeric modifier used in simple left-to-right numeric evaluation of a die roll expression.
-    Modifier(i8),
+    Modifier(i32),
 }
 
 
 impl DieRollTerm {
-    fn parse(drt: &str) -> DieRollTerm {
-        if drt.to_lowercase().contains('d') {
-            let v: Vec<&str> = drt.split("d").collect();
-            DieRollTerm::DieRoll {
-                multiplier: v[0].parse::<i8>().unwrap(),
-                sides: v[1].parse::<u8>().unwrap(),
+    /// Parses a single, whitespace-free term such as `3d6`, `-2d10`, `+5`, or `-2`.
+    ///
+    /// Numbers are parsed into 64-bit integers first so that oversized input is
+    /// reported as a descriptive [`D20Error`] instead of panicking.
+    fn parse(drt: &str) -> Result<DieRollTerm, D20Error> {
+        let lower = drt.to_lowercase();
+        if lower.contains('d') {
+            let mut parts = lower.splitn(2, 'd');
+            let mult_str = parts.next().unwrap_or("");
+            let sides_str = parts.next().unwrap_or("");
+
+            let multiplier = mult_str
+                .parse::<i64>()
+                .map_err(|_| D20Error::InvalidTerm(drt.to_string()))?;
+            let sides = sides_str
+                .parse::<u64>()
+                .map_err(|_| D20Error::InvalidTerm(drt.to_string()))?;
+
+            if multiplier.unsigned_abs() > MAX_DICE as u64 {
+                return Err(D20Error::DiceCountTooLarge {
+                    count: multiplier.unsigned_abs(),
+                    max: MAX_DICE,
+                });
             }
+            if sides == 0 {
+                return Err(D20Error::ZeroSidedDie);
+            }
+            if sides > MAX_SIDES as u64 {
+                return Err(D20Error::SidesTooLarge { sides, max: MAX_SIDES });
+            }
+
+            Ok(DieRollTerm::DieRoll {
+                multiplier: multiplier as i32,
+                sides: sides as u32,
+            })
         } else {
-            DieRollTerm::Modifier(drt.parse::<i8>().unwrap())
+            let modifier = drt
+                .parse::<i64>()
+                .map_err(|_| D20Error::InvalidTerm(drt.to_string()))?;
+            if modifier.unsigned_abs() > MAX_MODIFIER as u64 {
+                return Err(D20Error::ModifierTooLarge { modifier, max: MAX_MODIFIER });
+            }
+            Ok(DieRollTerm::Modifier(modifier as i32))
         }
     }
 
-
-    fn calculate(v: (DieRollTerm, Vec<i8>)) -> i32 {
+    /// Computes the signed contribution of an already-evaluated term to the total.
+    fn calculate(v: &(DieRollTerm, Vec<i32>)) -> i64 {
         match v.0 {
-            DieRollTerm::Modifier(n) => n as i32,
-            DieRollTerm::DieRoll { multiplier: m, .. } => {
-                let mut sum: i32 = v.1.iter().fold(0i32, |sum, &val| sum + val as i32);
-                if m < 0 {
-                    sum = sum * -1;
-                }
-                sum
+            DieRollTerm::Modifier(n) => n as i64,
+            DieRollTerm::DieRoll { multiplier, .. } => {
+                let sum: i64 = v.1.iter().map(|&val| val as i64).sum();
+                if multiplier < 0 { -sum } else { sum }
             }
         }
     }
 
-    fn evaluate(self) -> (DieRollTerm, Vec<i8>) {
+    /// Rolls the dice for this term (or echoes the modifier), returning the term
+    /// alongside the individual values produced.
+    fn evaluate(self) -> (DieRollTerm, Vec<i32>) {
         match self {
             DieRollTerm::Modifier(n) => (self, vec![n]),
-            DieRollTerm::DieRoll { multiplier: m, sides: s } => {
+            DieRollTerm::DieRoll { multiplier, sides } => {
                 let mut rng = rand::rng();
-                (self, (0..m.abs()).map(|_| rng.random_range(1..=(s as i8))).collect())
+                let rolls = (0..multiplier.unsigned_abs())
+                    .map(|_| rng.random_range(1..=sides) as i32)
+                    .collect();
+                (self, rolls)
             }
         }
     }
@@ -233,43 +330,37 @@ impl fmt::Display for DieRollTerm {
 }
 
 /// Evaluates the expression string input as a die roll expression (e.g. 3d6 + 4). The
-/// results are returned in a `Result` object that contains either a valid `Roll` or some
-/// text indicating why the function was unable to roll the dice / evaluate the expression.
-pub fn roll_dice<'a>(s: &'a str) -> Result<Roll, &'a str> {
+/// results are returned in a `Result` containing either a valid [`Roll`] or a
+/// [`D20Error`] describing why the expression could not be evaluated. This function
+/// never panics on malformed or out-of-range input.
+pub fn roll_dice(s: &str) -> Result<Roll, D20Error> {
     let s: String = s.split_whitespace().collect();
-    let terms: Vec<DieRollTerm> = parse_die_roll_terms(&s);
+    let terms = parse_die_roll_terms(&s)?;
 
-    if terms.len() == 0 {
-        Err("Invalid die roll expression: no die roll terms found.")
-    } else {
-
-        let v: Vec<_> = terms.into_iter().map(|t| t.evaluate()).collect();
-        let t = v.clone();
-
-        Ok(Roll {
-            drex: s,
-            values: v,
-            total: t.into_iter().fold(0i32, |sum, val| sum + DieRollTerm::calculate(val)),
-        })
+    if terms.is_empty() {
+        return Err(D20Error::EmptyExpression);
     }
+
+    let values: Vec<(DieRollTerm, Vec<i32>)> =
+        terms.into_iter().map(DieRollTerm::evaluate).collect();
+    let total = values.iter().map(DieRollTerm::calculate).sum();
+
+    Ok(Roll { drex: s, values, total })
 }
 
-fn parse_die_roll_terms(drex: &str) -> Vec<DieRollTerm> {
-    let mut terms = Vec::new();
-
-    let matches = DICE_RE.find_iter(drex);
-    for m in matches {
-        terms.push(DieRollTerm::parse(&drex[m.start()..m.end()]));
-    }
-    terms
+fn parse_die_roll_terms(drex: &str) -> Result<Vec<DieRollTerm>, D20Error> {
+    DICE_RE
+        .find_iter(drex)
+        .map(|m| DieRollTerm::parse(m.as_str()))
+        .collect()
 }
 
-/// Generates a random number within the specified range. Returns a `Result` containing
-/// either a valid signed 32-bit integer with the randomly generated number or some text 
-/// indicating the reason for failure.
-pub fn roll_range<'a>(min: i32, max: i32) -> Result<i32, &'a str> {
+/// Generates a random number within the specified inclusive range `[min, max]`.
+/// Returns a `Result` containing either the randomly generated `i32` or a
+/// [`D20Error::InvalidRange`] when `min > max`.
+pub fn roll_range(min: i32, max: i32) -> Result<i32, D20Error> {
     if min > max {
-        Err("Invalid range: min must be less than or equal to max")
+        Err(D20Error::InvalidRange { min, max })
     } else {
         Ok(rand::rng().random_range(min..=max))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,8 +71,14 @@
 //!
 //!
 use std::fmt;
-use rand::{thread_rng, Rng};
+use std::sync::LazyLock;
+use rand::RngExt;
 use regex::Regex;
+
+/// Compiled once on first use and reused for every parse. The pattern matches a
+/// signed die-roll term (`3d6`, `-2d10`) or a signed numeric modifier (`+5`, `-2`).
+static DICE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"([+-]?\s*\d+[dD]\d+|[+-]?\s*\d+)").unwrap());
 
 
 
@@ -207,7 +213,8 @@ impl DieRollTerm {
         match self {
             DieRollTerm::Modifier(n) => (self, vec![n]),
             DieRollTerm::DieRoll { multiplier: m, sides: s } => {
-                (self, (0..m.abs()).map(|_| thread_rng().gen_range(1, s as i8 + 1)).collect())
+                let mut rng = rand::rng();
+                (self, (0..m.abs()).map(|_| rng.random_range(1..=(s as i8))).collect())
             }
         }
     }
@@ -250,9 +257,7 @@ pub fn roll_dice<'a>(s: &'a str) -> Result<Roll, &'a str> {
 fn parse_die_roll_terms(drex: &str) -> Vec<DieRollTerm> {
     let mut terms = Vec::new();
 
-    let re = Regex::new(r"([+-]?\s*\d+[dD]\d+|[+-]?\s*\d+)").unwrap();
-
-    let matches = re.find_iter(drex);
+    let matches = DICE_RE.find_iter(drex);
     for m in matches {
         terms.push(DieRollTerm::parse(&drex[m.start()..m.end()]));
     }
@@ -266,7 +271,7 @@ pub fn roll_range<'a>(min: i32, max: i32) -> Result<i32, &'a str> {
     if min > max {
         Err("Invalid range: min must be less than or equal to max")
     } else {
-        Ok(thread_rng().gen_range(min, max + 1))
+        Ok(rand::rng().random_range(min..=max))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,37 +25,29 @@
 //!
 //! # Examples
 //! ```
-//! fn main() {
-//!     let r = d20::roll_dice("3d6 + 4").unwrap();
-//!     assert!(r.total > 6);
-//!     let r = d20::roll_dice("1d1-3").unwrap();
-//!     assert_eq!(r.total, -2);
+//! let r = d20::roll_dice("3d6 + 4").unwrap();
+//! assert!(r.total > 6);
+//! let r = d20::roll_dice("1d1-3").unwrap();
+//! assert_eq!(r.total, -2);
 //!
-//!     let r = d20::roll_dice("roll four chickens and add six ferrets");
-//!     match r {
-//!        Ok(_) => assert!(false), // this should NOT be ok, fail
-//!        Err(_) => assert!(true), // bad expressions produce errors
-//!    }
-//! }
+//! // Bad expressions produce errors rather than panicking.
+//! assert!(d20::roll_dice("roll four chickens and add six ferrets").is_err());
 //! ```
 //! ### Iterating Roll
-//! A valid `Roll` can be converted into an open ended iterator via its `into_iter()` method, providing successive
+//! A valid `Roll` can be turned into an open-ended iterator via its `rolls()` method, providing successive
 //! rolls of the given die roll expression.
 //!
 //! _Note that it will be necessary to constrain the iterator via `take(n)`._
-//! 
+//!
 //! ```rust
 //! use d20::*;
 //!
-//! fn main() {
-//!     let v: Vec<Roll> = d20::roll_dice("3d6").unwrap().into_iter().take(3).collect();
+//! let v: Vec<Roll> = d20::roll_dice("3d6").unwrap().rolls().take(3).collect();
 //!
-//!     assert_eq!(v.len(), 3);
-//!     assert!(v[0].total >= 3 && v[0].total <= 18);
-//!     assert!(v[1].total >= 3 && v[1].total <= 18);
-//!     assert!(v[2].total >= 3 && v[2].total <= 18);     
-//! }
-//!
+//! assert_eq!(v.len(), 3);
+//! assert!(v[0].total >= 3 && v[0].total <= 18);
+//! assert!(v[1].total >= 3 && v[1].total <= 18);
+//! assert!(v[2].total >= 3 && v[2].total <= 18);
 //! ```
 //!
 //! ### Range Rolls
@@ -63,16 +55,13 @@
 //! will do just that.
 //!
 //! ```rust
-//! # fn main() {
-//!     let rg = d20::roll_range(1,100).unwrap();
-//!     assert!(rg >= 1 && rg <= 100);
-//! # }
+//! let rg = d20::roll_range(1, 100).unwrap();
+//! assert!((1..=100).contains(&rg));
 //! ```
-//!
 //!
 use std::fmt;
 use std::sync::LazyLock;
-use rand::RngExt;
+use rand::{Rng, RngExt};
 use regex::Regex;
 
 /// Matches a single term anchored at the start of the remaining input, allowing
@@ -164,8 +153,9 @@ pub enum D20Error {
 ///
 /// The `total` field contains the net result of evaluating the entire roll expression.
 ///
-/// You can evaluate a roll expression (perform a roll) mutliple times by converting it into an iterator.
-#[derive(Debug)]
+/// You can evaluate a roll expression (perform a roll) multiple times by calling
+/// [`Roll::rolls`], which returns an iterator of fresh rolls.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Roll {
     /// A die roll expression conforming to the format specification
     pub drex: String,
@@ -183,55 +173,56 @@ pub struct Roll {
 ///
 /// `3d6[3,4,6]+5 (Total: 18)`
 impl fmt::Display for Roll {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {        
-        let mut out = String::new();
-
-        for i in 0..self.values.len() {
-            let ref val = self.values[i];
-            match val.0 {
-                DieRollTerm::Modifier(_) => out = out + format!("{}", &val.0).as_str(),
-                DieRollTerm::DieRoll { .. } => {
-                    out = out + format!("{}{:?}", &val.0, val.1).as_str();
-                }
-            };
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for (term, values) in &self.values {
+            match term {
+                DieRollTerm::Modifier(_) => write!(f, "{term}")?,
+                DieRollTerm::DieRoll { .. } => write!(f, "{term}{values:?}")?,
+            }
         }
-        out = format!("{} (Total: {})", out, self.total);
-        write!(f, "{}", out)
+        write!(f, " (Total: {})", self.total)
     }
 }
 
-/// Converts an evaluated roll expression into an iterator, allowing the expression
-/// to be evaluated (including re-rolling of dice) multiple times. 
-impl IntoIterator for Roll {
-    type Item = Roll;
-    type IntoIter = RollIterator;
-
-    fn into_iter(self) -> Self::IntoIter {
+impl Roll {
+    /// Returns an iterator that re-rolls this expression on each call to `next`,
+    /// yielding a fresh [`Roll`] every time.
+    ///
+    /// The iterator is **infinite**, so constrain it with
+    /// [`Iterator::take`]. Unlike re-parsing the expression, it reuses the
+    /// already-parsed terms, so only the dice are re-rolled.
+    ///
+    /// ```
+    /// let stats: Vec<d20::Roll> = d20::roll_dice("3d6").unwrap().rolls().take(6).collect();
+    /// assert_eq!(stats.len(), 6);
+    /// ```
+    pub fn rolls(&self) -> RollIterator {
         RollIterator {
-            roll: self,
-            index: 0,
+            drex: self.drex.clone(),
+            terms: self.values.iter().map(|(term, _)| term.clone()).collect(),
         }
     }
 }
 
-/// A `RollIterator` is created when `into_iter()` is called on a `Roll`.
+/// An infinite iterator of fresh rolls, created by [`Roll::rolls`].
 pub struct RollIterator {
-    roll: Roll,
-    index: usize,
+    drex: String,
+    terms: Vec<DieRollTerm>,
 }
 
 impl Iterator for RollIterator {
     type Item = Roll;
 
     fn next(&mut self) -> Option<Roll> {
-        let result = roll_dice(&self.roll.drex);
-        match result {
-            Ok(r) => {
-                self.index += 1;
-                Some(r)
-            }
-            Err(_) => return None,
-        }
+        let mut rng = rand::rng();
+        let values: Vec<(DieRollTerm, Vec<i32>)> = self
+            .terms
+            .iter()
+            .cloned()
+            .map(|term| term.evaluate(&mut rng))
+            .collect();
+        let total = values.iter().map(DieRollTerm::calculate).sum();
+        Some(Roll { drex: self.drex.clone(), values, total })
     }
 }
 
@@ -316,13 +307,12 @@ impl DieRollTerm {
         }
     }
 
-    /// Rolls the dice for this term (or echoes the modifier), returning the term
-    /// alongside the individual values produced.
-    fn evaluate(self) -> (DieRollTerm, Vec<i32>) {
+    /// Rolls the dice for this term (or echoes the modifier) using `rng`,
+    /// returning the term alongside the individual values produced.
+    fn evaluate<R: Rng + ?Sized>(self, rng: &mut R) -> (DieRollTerm, Vec<i32>) {
         match self {
             DieRollTerm::Modifier(n) => (self, vec![n]),
             DieRollTerm::DieRoll { multiplier, sides } => {
-                let mut rng = rand::rng();
                 let rolls = (0..multiplier.unsigned_abs())
                     .map(|_| rng.random_range(1..=sides) as i32)
                     .collect();
@@ -349,6 +339,13 @@ impl fmt::Display for DieRollTerm {
 /// [`D20Error`] describing why the expression could not be evaluated. This function
 /// never panics on malformed or out-of-range input.
 pub fn roll_dice(s: &str) -> Result<Roll, D20Error> {
+    roll_dice_with_rng(s, &mut rand::rng())
+}
+
+/// Like [`roll_dice`], but draws randomness from the supplied `rng` instead of
+/// the thread-local generator. Pass a seeded RNG (e.g. `StdRng::seed_from_u64`)
+/// for deterministic, reproducible rolls.
+pub fn roll_dice_with_rng<R: Rng + ?Sized>(s: &str, rng: &mut R) -> Result<Roll, D20Error> {
     let drex = s.trim().to_string();
     let terms = parse_die_roll_terms(&drex)?;
 
@@ -357,7 +354,7 @@ pub fn roll_dice(s: &str) -> Result<Roll, D20Error> {
     }
 
     let values: Vec<(DieRollTerm, Vec<i32>)> =
-        terms.into_iter().map(DieRollTerm::evaluate).collect();
+        terms.into_iter().map(|t| t.evaluate(rng)).collect();
     let total = values.iter().map(DieRollTerm::calculate).sum();
 
     Ok(Roll { drex, values, total })
@@ -405,10 +402,19 @@ fn parse_die_roll_terms(drex: &str) -> Result<Vec<DieRollTerm>, D20Error> {
 /// Returns a `Result` containing either the randomly generated `i32` or a
 /// [`D20Error::InvalidRange`] when `min > max`.
 pub fn roll_range(min: i32, max: i32) -> Result<i32, D20Error> {
+    roll_range_with_rng(min, max, &mut rand::rng())
+}
+
+/// Like [`roll_range`], but draws randomness from the supplied `rng`.
+pub fn roll_range_with_rng<R: Rng + ?Sized>(
+    min: i32,
+    max: i32,
+    rng: &mut R,
+) -> Result<i32, D20Error> {
     if min > max {
         Err(D20Error::InvalidRange { min, max })
     } else {
-        Ok(rand::rng().random_range(min..=max))
+        Ok(rng.random_range(min..=max))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 //! D20
 //!
 //! **D20** is a simple crate designed to evaluate _roll expressions_. A _roll expression_ is an
-//! english-language string that reflects the intent of a dungeon or game master to perform a 
+//! english-language string that reflects the intent of a dungeon or game master to perform a
 //! particular roll.
 //!
-//! For example, in a tabletop game you may frequently hear phrases like _"roll 2d10"_, or 
+//! For example, in a tabletop game you may frequently hear phrases like _"roll 2d10"_, or
 //! _"roll 3d6 and add 5"_. These are roll expressions, and the components within them are
 //! what we call _die roll terms_. A _die roll term_ is either a term that calls for the rolling
 //! of an n-sided die x times (e.g. 3d6) or a modifier that simply adds or subtracts a constant value
@@ -59,10 +59,10 @@
 //! assert!((1..=100).contains(&rg));
 //! ```
 //!
-use std::fmt;
-use std::sync::LazyLock;
 use rand::{Rng, RngExt};
 use regex::Regex;
+use std::fmt;
+use std::sync::LazyLock;
 
 /// Matches a single term anchored at the start of the remaining input, allowing
 /// surrounding whitespace. Captures the optional leading sign, and either a die
@@ -141,11 +141,11 @@ pub enum D20Error {
 }
 
 /// Represents the _results_ of an evaluated die roll expression.
-/// 
+///
 /// The `Roll` struct contains the original _die roll expression_ passed to the `roll_dice()`
 /// function.
 ///
-/// The list of `values` will always be a vector containing at least one element because roll 
+/// The list of `values` will always be a vector containing at least one element because roll
 /// expressions are not valid without at least 1 term. Each resulting value is a tuple containing
 /// the parsed `DieRollTerm` and a vector of values. For `DieRollTerm::Modifier` terms, this will be a single-element
 /// vector containing the modifier value. For `DieRollTerm::DieRoll` terms, this will be a vector
@@ -165,8 +165,7 @@ pub struct Roll {
     pub total: i64,
 }
 
-
-/// Formats roll results, including die rolls, in a human-readable string. 
+/// Formats roll results, including die rolls, in a human-readable string.
 ///
 /// For example, if the original expression was `3d6+5`, formatting the `Roll` struct
 /// might result in the following text:
@@ -222,7 +221,11 @@ impl Iterator for RollIterator {
             .map(|term| term.evaluate(&mut rng))
             .collect();
         let total = values.iter().map(DieRollTerm::calculate).sum();
-        Some(Roll { drex: self.drex.clone(), values, total })
+        Some(Roll {
+            drex: self.drex.clone(),
+            values,
+            total,
+        })
     }
 }
 
@@ -241,7 +244,6 @@ pub enum DieRollTerm {
     /// Numeric modifier used in simple left-to-right numeric evaluation of a die roll expression.
     Modifier(i32),
 }
-
 
 impl DieRollTerm {
     /// Parses a single, whitespace-free term such as `3d6`, `-2d10`, `+5`, or `-2`.
@@ -278,7 +280,10 @@ impl DieRollTerm {
                 return Err(D20Error::ZeroSidedDie);
             }
             if sides > MAX_SIDES as u64 {
-                return Err(D20Error::SidesTooLarge { sides, max: MAX_SIDES });
+                return Err(D20Error::SidesTooLarge {
+                    sides,
+                    max: MAX_SIDES,
+                });
             }
 
             Ok(DieRollTerm::DieRoll {
@@ -290,7 +295,10 @@ impl DieRollTerm {
                 .parse::<i64>()
                 .map_err(|_| D20Error::InvalidTerm(drt.to_string()))?;
             if modifier.unsigned_abs() > MAX_MODIFIER as u64 {
-                return Err(D20Error::ModifierTooLarge { modifier, max: MAX_MODIFIER });
+                return Err(D20Error::ModifierTooLarge {
+                    modifier,
+                    max: MAX_MODIFIER,
+                });
             }
             Ok(DieRollTerm::Modifier(modifier as i32))
         }
@@ -324,12 +332,15 @@ impl DieRollTerm {
 
 /// Formats an individual die roll term in a human-friendly fashion. For `Modifier` terms,
 /// this will force the printing of a + or - sign before the modifier value. For `DieRoll`
-/// terms, this displays the term in the form `5d10`. 
+/// terms, this displays the term in the form `5d10`.
 impl fmt::Display for DieRollTerm {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             DieRollTerm::Modifier(n) => write!(f, "{:+}", n),
-            DieRollTerm::DieRoll { multiplier: m, sides: s } => write!(f, "{}d{}", m, s),
+            DieRollTerm::DieRoll {
+                multiplier: m,
+                sides: s,
+            } => write!(f, "{}d{}", m, s),
         }
     }
 }
@@ -353,11 +364,14 @@ pub fn roll_dice_with_rng<R: Rng + ?Sized>(s: &str, rng: &mut R) -> Result<Roll,
         return Err(D20Error::EmptyExpression);
     }
 
-    let values: Vec<(DieRollTerm, Vec<i32>)> =
-        terms.into_iter().map(|t| t.evaluate(rng)).collect();
+    let values: Vec<(DieRollTerm, Vec<i32>)> = terms.into_iter().map(|t| t.evaluate(rng)).collect();
     let total = values.iter().map(DieRollTerm::calculate).sum();
 
-    Ok(Roll { drex, values, total })
+    Ok(Roll {
+        drex,
+        values,
+        total,
+    })
 }
 
 /// Parses a full roll expression into its terms, validating the *entire* input.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,6 @@
 //!
 //! # Examples
 //! ```
-//! extern crate d20;
-//!
 //! fn main() {
 //!     let r = d20::roll_dice("3d6 + 4").unwrap();
 //!     assert!(r.total > 6);
@@ -47,7 +45,6 @@
 //! _Note that it will be necessary to constrain the iterator via `take(n)`._
 //! 
 //! ```rust
-//! extern crate d20;
 //! use d20::*;
 //!
 //! fn main() {
@@ -66,17 +63,13 @@
 //! will do just that.
 //!
 //! ```rust
-//! # extern crate d20;
 //! # fn main() {
 //!     let rg = d20::roll_range(1,100).unwrap();
 //!     assert!(rg >= 1 && rg <= 100);
 //! # }
 //! ```
 //!
-//! 
-extern crate rand;
-extern crate regex;
-
+//!
 use std::fmt;
 use rand::{thread_rng, Rng};
 use regex::Regex;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,10 +75,14 @@ use std::sync::LazyLock;
 use rand::RngExt;
 use regex::Regex;
 
-/// Compiled once on first use and reused for every parse. The pattern matches a
-/// signed die-roll term (`3d6`, `-2d10`) or a signed numeric modifier (`+5`, `-2`).
-static DICE_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"([+-]?\s*\d+[dD]\d+|[+-]?\s*\d+)").unwrap());
+/// Matches a single term anchored at the start of the remaining input, allowing
+/// surrounding whitespace. Captures the optional leading sign, and either a die
+/// roll (`count` may be empty for shorthand like `d6`) or a numeric modifier.
+/// Compiled once on first use and reused for every parse.
+static TERM_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^\s*(?P<sign>[+-]?)\s*(?:(?P<count>\d*)[dD](?P<sides>\d+)|(?P<modval>\d+))\s*")
+        .unwrap()
+});
 
 /// Maximum number of dice a single term may roll (e.g. the `100` in `100d6`).
 /// Larger counts are rejected with [`D20Error::DiceCountTooLarge`] rather than
@@ -102,9 +106,14 @@ pub enum D20Error {
     /// The expression contained no recognizable die-roll terms.
     #[error("invalid die roll expression: no die roll terms found")]
     EmptyExpression,
-    /// A term could not be parsed (e.g. a number too large to fit a 64-bit integer).
+    /// A term could not be parsed (e.g. a number too large to fit a 64-bit integer),
+    /// or trailing/garbage characters were found that are not part of a valid term.
     #[error("invalid term: '{0}'")]
     InvalidTerm(String),
+    /// Two terms were placed next to each other without a `+` or `-` operator
+    /// between them (e.g. `2d6 5`).
+    #[error("missing '+' or '-' operator before '{0}'")]
+    MissingOperator(String),
     /// A die was specified with zero sides, which cannot be rolled.
     #[error("invalid die: a die must have at least one side")]
     ZeroSidedDie,
@@ -255,9 +264,15 @@ impl DieRollTerm {
             let mult_str = parts.next().unwrap_or("");
             let sides_str = parts.next().unwrap_or("");
 
-            let multiplier = mult_str
-                .parse::<i64>()
-                .map_err(|_| D20Error::InvalidTerm(drt.to_string()))?;
+            // An empty or sign-only count means a single die (e.g. `d6` == `1d6`,
+            // `-d6` == `-1d6`).
+            let multiplier = match mult_str {
+                "" | "+" => 1,
+                "-" => -1,
+                other => other
+                    .parse::<i64>()
+                    .map_err(|_| D20Error::InvalidTerm(drt.to_string()))?,
+            };
             let sides = sides_str
                 .parse::<u64>()
                 .map_err(|_| D20Error::InvalidTerm(drt.to_string()))?;
@@ -334,8 +349,8 @@ impl fmt::Display for DieRollTerm {
 /// [`D20Error`] describing why the expression could not be evaluated. This function
 /// never panics on malformed or out-of-range input.
 pub fn roll_dice(s: &str) -> Result<Roll, D20Error> {
-    let s: String = s.split_whitespace().collect();
-    let terms = parse_die_roll_terms(&s)?;
+    let drex = s.trim().to_string();
+    let terms = parse_die_roll_terms(&drex)?;
 
     if terms.is_empty() {
         return Err(D20Error::EmptyExpression);
@@ -345,14 +360,45 @@ pub fn roll_dice(s: &str) -> Result<Roll, D20Error> {
         terms.into_iter().map(DieRollTerm::evaluate).collect();
     let total = values.iter().map(DieRollTerm::calculate).sum();
 
-    Ok(Roll { drex: s, values, total })
+    Ok(Roll { drex, values, total })
 }
 
+/// Parses a full roll expression into its terms, validating the *entire* input.
+///
+/// Terms are consumed left to right. The first term may carry an optional sign;
+/// every later term must be preceded by an explicit `+`/`-` operator. Any
+/// characters that are not part of a valid term produce an error, so unlike a
+/// permissive `find_iter` scan this rejects garbage such as `"I have 5 apples"`
+/// and ambiguous juxtapositions such as `"2d6 5"` rather than silently
+/// extracting numbers from them.
 fn parse_die_roll_terms(drex: &str) -> Result<Vec<DieRollTerm>, D20Error> {
-    DICE_RE
-        .find_iter(drex)
-        .map(|m| DieRollTerm::parse(m.as_str()))
-        .collect()
+    let mut terms = Vec::new();
+    let mut pos = 0;
+
+    while pos < drex.len() {
+        let rest = &drex[pos..];
+        let caps = TERM_RE
+            .captures(rest)
+            .ok_or_else(|| D20Error::InvalidTerm(rest.to_string()))?;
+
+        let sign = caps.name("sign").map_or("", |m| m.as_str());
+        if !terms.is_empty() && sign.is_empty() {
+            return Err(D20Error::MissingOperator(rest.to_string()));
+        }
+
+        let token = match caps.name("sides") {
+            Some(sides) => {
+                let count = caps.name("count").map_or("", |m| m.as_str());
+                format!("{sign}{count}d{}", sides.as_str())
+            }
+            None => format!("{sign}{}", caps.name("modval").unwrap().as_str()),
+        };
+        terms.push(DieRollTerm::parse(&token)?);
+
+        pos += caps.get(0).unwrap().end();
+    }
+
+    Ok(terms)
 }
 
 /// Generates a random number within the specified inclusive range `[min, max]`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,14 +142,15 @@ pub enum D20Error {
 
 /// Represents the _results_ of an evaluated die roll expression.
 ///
-/// The `Roll` struct contains the original _die roll expression_ passed to the `roll_dice()`
-/// function.
+/// The `Roll` struct contains the original _die roll expression_ passed to
+/// [`roll_dice`], the evaluated result of each term, and the net total.
 ///
-/// The list of `values` will always be a vector containing at least one element because roll
-/// expressions are not valid without at least 1 term. Each resulting value is a tuple containing
-/// the parsed `DieRollTerm` and a vector of values. For `DieRollTerm::Modifier` terms, this will be a single-element
-/// vector containing the modifier value. For `DieRollTerm::DieRoll` terms, this will be a vector
-/// containing the results of each die roll.
+/// `terms` always contains at least one element, because a roll expression is
+/// not valid without at least one term. Each element is a [`TermResult`]: a
+/// [`TermResult::Dice`] carries the multiplier, sides, and individual die
+/// results, while a [`TermResult::Modifier`] carries the constant value. This
+/// keeps the data self-describing — modifiers are not represented as fake
+/// single-element "rolls".
 ///
 /// The `total` field contains the net result of evaluating the entire roll expression.
 ///
@@ -157,12 +158,90 @@ pub enum D20Error {
 /// [`Roll::rolls`], which returns an iterator of fresh rolls.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Roll {
-    /// A die roll expression conforming to the format specification
+    /// The original die roll expression that produced this result.
     pub drex: String,
-    /// The results of evaluating each term in the expression
-    pub values: Vec<(DieRollTerm, Vec<i32>)>,
-    /// The net final result of evaluating all terms in the expression
+    /// The evaluated result of each term in the expression, in order.
+    pub terms: Vec<TermResult>,
+    /// The net final result of evaluating all terms in the expression.
     pub total: i64,
+}
+
+/// The evaluated result of a single term within a roll expression.
+///
+/// Returned as the elements of [`Roll::terms`]. A [`Dice`](TermResult::Dice)
+/// term records what was rolled; a [`Modifier`](TermResult::Modifier) term
+/// records a constant. Use [`TermResult::subtotal`] for the signed contribution
+/// of the term to the [`Roll::total`], and [`TermResult::rolls`] for the
+/// individual die results (empty for a modifier).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TermResult {
+    /// A die-roll term and the individual values it produced.
+    Dice {
+        /// Number of dice rolled. A negative value subtracts this term's total.
+        multiplier: i32,
+        /// Number of sides on each die.
+        sides: u32,
+        /// The individual die results, each in `1..=sides`. Contains
+        /// `multiplier.abs()` values.
+        rolls: Vec<u32>,
+    },
+    /// A constant numeric modifier such as `+5` or `-2`.
+    Modifier(i32),
+}
+
+impl TermResult {
+    /// The signed contribution of this term to the [`Roll::total`].
+    ///
+    /// For a [`Dice`](TermResult::Dice) term this is the sum of its rolls,
+    /// negated when the multiplier is negative; for a
+    /// [`Modifier`](TermResult::Modifier) it is the modifier value.
+    pub fn subtotal(&self) -> i64 {
+        match self {
+            TermResult::Modifier(n) => *n as i64,
+            TermResult::Dice {
+                multiplier, rolls, ..
+            } => {
+                let sum: i64 = rolls.iter().map(|&r| r as i64).sum();
+                if *multiplier < 0 { -sum } else { sum }
+            }
+        }
+    }
+
+    /// The individual die results for a [`Dice`](TermResult::Dice) term, or an
+    /// empty slice for a [`Modifier`](TermResult::Modifier).
+    pub fn rolls(&self) -> &[u32] {
+        match self {
+            TermResult::Dice { rolls, .. } => rolls,
+            TermResult::Modifier(_) => &[],
+        }
+    }
+
+    /// Recovers the parsed [`DieRollTerm`] that produced this result, so the
+    /// term can be re-rolled without re-parsing the expression.
+    fn term(&self) -> DieRollTerm {
+        match *self {
+            TermResult::Dice {
+                multiplier, sides, ..
+            } => DieRollTerm::DieRoll { multiplier, sides },
+            TermResult::Modifier(n) => DieRollTerm::Modifier(n),
+        }
+    }
+}
+
+/// Formats a single evaluated term: `3d6[4, 1, 6]` for dice, `+5` for modifiers.
+impl fmt::Display for TermResult {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            TermResult::Modifier(n) => write!(f, "{n:+}"),
+            TermResult::Dice {
+                multiplier,
+                sides,
+                rolls,
+            } => {
+                write!(f, "{multiplier}d{sides}{rolls:?}")
+            }
+        }
+    }
 }
 
 /// Formats roll results, including die rolls, in a human-readable string.
@@ -173,11 +252,8 @@ pub struct Roll {
 /// `3d6[3,4,6]+5 (Total: 18)`
 impl fmt::Display for Roll {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        for (term, values) in &self.values {
-            match term {
-                DieRollTerm::Modifier(_) => write!(f, "{term}")?,
-                DieRollTerm::DieRoll { .. } => write!(f, "{term}{values:?}")?,
-            }
+        for term in &self.terms {
+            write!(f, "{term}")?;
         }
         write!(f, " (Total: {})", self.total)
     }
@@ -198,7 +274,7 @@ impl Roll {
     pub fn rolls(&self) -> RollIterator {
         RollIterator {
             drex: self.drex.clone(),
-            terms: self.values.iter().map(|(term, _)| term.clone()).collect(),
+            terms: self.terms.iter().map(TermResult::term).collect(),
         }
     }
 }
@@ -214,26 +290,28 @@ impl Iterator for RollIterator {
 
     fn next(&mut self) -> Option<Roll> {
         let mut rng = rand::rng();
-        let values: Vec<(DieRollTerm, Vec<i32>)> = self
+        let terms: Vec<TermResult> = self
             .terms
             .iter()
             .cloned()
             .map(|term| term.evaluate(&mut rng))
             .collect();
-        let total = values.iter().map(DieRollTerm::calculate).sum();
+        let total = terms.iter().map(TermResult::subtotal).sum();
         Some(Roll {
             drex: self.drex.clone(),
-            values,
+            terms,
             total,
         })
     }
 }
 
-/// Represents an individual term within a die roll expression. Terms can either be numeric
-/// modifiers like `+5` or `-2` or they can be terms indicating die rolls.
+/// An individual term parsed from a die roll expression, before it is rolled.
+///
+/// This is an internal representation; callers receive the evaluated
+/// [`TermResult`] instead, via [`Roll::terms`].
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DieRollTerm {
-    /// Indicates a die roll term to roll `multiplier` dice with `sides` sides.
+enum DieRollTerm {
+    /// A die roll term: roll `multiplier` dice with `sides` sides each.
     DieRoll {
         /// Number of times to roll the given die. A negative value subtracts the
         /// rolled total from the expression. Bounded by [`MAX_DICE`] in magnitude.
@@ -304,43 +382,21 @@ impl DieRollTerm {
         }
     }
 
-    /// Computes the signed contribution of an already-evaluated term to the total.
-    fn calculate(v: &(DieRollTerm, Vec<i32>)) -> i64 {
-        match v.0 {
-            DieRollTerm::Modifier(n) => n as i64,
-            DieRollTerm::DieRoll { multiplier, .. } => {
-                let sum: i64 = v.1.iter().map(|&val| val as i64).sum();
-                if multiplier < 0 { -sum } else { sum }
-            }
-        }
-    }
-
     /// Rolls the dice for this term (or echoes the modifier) using `rng`,
-    /// returning the term alongside the individual values produced.
-    fn evaluate<R: Rng + ?Sized>(self, rng: &mut R) -> (DieRollTerm, Vec<i32>) {
+    /// producing the evaluated [`TermResult`].
+    fn evaluate<R: Rng + ?Sized>(self, rng: &mut R) -> TermResult {
         match self {
-            DieRollTerm::Modifier(n) => (self, vec![n]),
+            DieRollTerm::Modifier(n) => TermResult::Modifier(n),
             DieRollTerm::DieRoll { multiplier, sides } => {
                 let rolls = (0..multiplier.unsigned_abs())
-                    .map(|_| rng.random_range(1..=sides) as i32)
+                    .map(|_| rng.random_range(1..=sides))
                     .collect();
-                (self, rolls)
+                TermResult::Dice {
+                    multiplier,
+                    sides,
+                    rolls,
+                }
             }
-        }
-    }
-}
-
-/// Formats an individual die roll term in a human-friendly fashion. For `Modifier` terms,
-/// this will force the printing of a + or - sign before the modifier value. For `DieRoll`
-/// terms, this displays the term in the form `5d10`.
-impl fmt::Display for DieRollTerm {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            DieRollTerm::Modifier(n) => write!(f, "{:+}", n),
-            DieRollTerm::DieRoll {
-                multiplier: m,
-                sides: s,
-            } => write!(f, "{}d{}", m, s),
         }
     }
 }
@@ -364,14 +420,10 @@ pub fn roll_dice_with_rng<R: Rng + ?Sized>(s: &str, rng: &mut R) -> Result<Roll,
         return Err(D20Error::EmptyExpression);
     }
 
-    let values: Vec<(DieRollTerm, Vec<i32>)> = terms.into_iter().map(|t| t.evaluate(rng)).collect();
-    let total = values.iter().map(DieRollTerm::calculate).sum();
+    let terms: Vec<TermResult> = terms.into_iter().map(|t| t.evaluate(rng)).collect();
+    let total = terms.iter().map(TermResult::subtotal).sum();
 
-    Ok(Roll {
-        drex,
-        values,
-        total,
-    })
+    Ok(Roll { drex, terms, total })
 }
 
 /// Parses a full roll expression into its terms, validating the *entire* input.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,6 @@
-use crate::Roll;
 use crate::DieRollTerm;
-use crate::{roll_dice, roll_range, parse_die_roll_terms};
+use crate::Roll;
+use crate::{parse_die_roll_terms, roll_dice, roll_range};
 
 #[test]
 fn die_roll_expression_parsed() {
@@ -10,7 +10,11 @@ fn die_roll_expression_parsed() {
     let mf = "50+2d8-1d4".to_string();
 
     let pv = parse_die_roll_terms(&pd).unwrap();
-    if let DieRollTerm::DieRoll { multiplier: m, sides: s } = pv[0] {
+    if let DieRollTerm::DieRoll {
+        multiplier: m,
+        sides: s,
+    } = pv[0]
+    {
         assert_eq!(m, 3);
         assert_eq!(s, 12);
     }
@@ -19,7 +23,11 @@ fn die_roll_expression_parsed() {
     }
 
     let nv = parse_die_roll_terms(&nd).unwrap();
-    if let DieRollTerm::DieRoll { multiplier: m, sides: s } = nv[0] {
+    if let DieRollTerm::DieRoll {
+        multiplier: m,
+        sides: s,
+    } = nv[0]
+    {
         assert_eq!(m, -4);
         assert_eq!(s, 10);
     }
@@ -31,15 +39,22 @@ fn die_roll_expression_parsed() {
     if let DieRollTerm::Modifier(n) = mv[0] {
         assert_eq!(n, 50);
     }
-    if let DieRollTerm::DieRoll { multiplier: m, sides: s } = mv[1] {
+    if let DieRollTerm::DieRoll {
+        multiplier: m,
+        sides: s,
+    } = mv[1]
+    {
         assert_eq!(m, 2);
         assert_eq!(s, 8);
     }
-    if let DieRollTerm::DieRoll { multiplier: m, sides: s } = mv[2] {
+    if let DieRollTerm::DieRoll {
+        multiplier: m,
+        sides: s,
+    } = mv[2]
+    {
         assert_eq!(m, -1);
         assert_eq!(s, 4);
     }
-
 }
 
 #[test]
@@ -48,7 +63,11 @@ fn die_roll_term_parsed() {
     let mfy = "+7".to_string();
     let drt = DieRollTerm::parse(&drt).unwrap();
     let mfy = DieRollTerm::parse(&mfy).unwrap();
-    if let DieRollTerm::DieRoll { multiplier: m, sides: s } = drt {
+    if let DieRollTerm::DieRoll {
+        multiplier: m,
+        sides: s,
+    } = drt
+    {
         assert_eq!(m, 3);
         assert_eq!(s, 6);
     } else {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,5 @@
 use crate::DieRollTerm;
-use crate::Roll;
+use crate::{Roll, TermResult};
 use crate::{parse_die_roll_terms, roll_dice, roll_range};
 
 #[test]
@@ -89,17 +89,10 @@ fn die_roll_term_calculated() {
     let pm = DieRollTerm::parse("+7").unwrap().evaluate(&mut rng);
     let nm = DieRollTerm::parse("-7").unwrap().evaluate(&mut rng);
 
-    let dtr = DieRollTerm::calculate(&dt);
-    assert_eq!(dtr, 6);
-
-    let ntr = DieRollTerm::calculate(&nt);
-    assert_eq!(ntr, -4);
-
-    let pmr = DieRollTerm::calculate(&pm);
-    assert_eq!(pmr, 7);
-
-    let nmr = DieRollTerm::calculate(&nm);
-    assert_eq!(nmr, -7);
+    assert_eq!(dt.subtotal(), 6);
+    assert_eq!(nt.subtotal(), -4);
+    assert_eq!(pm.subtotal(), 7);
+    assert_eq!(nm.subtotal(), -7);
 }
 
 #[test]
@@ -107,10 +100,8 @@ fn die_roll_term_evaluated() {
     let drt = DieRollTerm::parse("3d1").unwrap();
     let v = drt.evaluate(&mut rand::rng());
 
-    assert_eq!(v.1.len(), 3);
-    assert_eq!(v.1[0], 1);
-    assert_eq!(v.1[1], 1);
-    assert_eq!(v.1[2], 1);
+    assert_eq!(v.rolls().len(), 3);
+    assert_eq!(v.rolls(), [1, 1, 1]);
 }
 
 #[test]
@@ -121,10 +112,11 @@ fn die_roll_term_modifier_evaluated() {
     let v1 = mfy.evaluate(&mut rng);
     let v2 = mfy2.evaluate(&mut rng);
 
-    assert_eq!(v1.1.len(), 1);
-    assert_eq!(v2.1.len(), 1);
-    assert_eq!(v1.1[0], 7);
-    assert_eq!(v2.1[0], -7);
+    // A modifier has no individual rolls; its value is its subtotal.
+    assert!(v1.rolls().is_empty());
+    assert!(v2.rolls().is_empty());
+    assert_eq!(v1.subtotal(), 7);
+    assert_eq!(v2.subtotal(), -7);
 }
 
 #[test]
@@ -135,10 +127,10 @@ fn roll_dice_produces_roll_for_valid_expression() {
 
     // drex now preserves the original expression (C12), not a stripped form.
     assert_eq!(r.drex, "2d6 + 6 + 4d10".to_string());
-    assert_eq!(r.values.len(), 3);
-    assert_eq!(r.values[0].1.len(), 2);
-    assert_eq!(r.values[1].1.len(), 1);
-    assert_eq!(r.values[2].1.len(), 4);
+    assert_eq!(r.terms.len(), 3);
+    assert_eq!(r.terms[0].rolls().len(), 2); // two d6 rolls
+    assert_eq!(r.terms[1].rolls().len(), 0); // a modifier has no rolls
+    assert_eq!(r.terms[2].rolls().len(), 4); // four d10 rolls
 
     let s = "3d1 + 2d1 + 1";
     let r = roll_dice(s);
@@ -183,17 +175,15 @@ fn iterator_yields_new_results() {
 }
 
 #[test]
-fn die_roll_term_displays_properly() {
-    let drt = DieRollTerm::parse("3d6").unwrap();
-    let pm = DieRollTerm::parse("5").unwrap();
-    let nm = DieRollTerm::parse("-6").unwrap();
-
-    let out = format!("{}", drt);
-    assert_eq!(out, "3d6");
-    let out = format!("{}", pm);
-    assert_eq!(out, "+5");
-    let out = format!("{}", nm);
-    assert_eq!(out, "-6");
+fn term_result_displays_properly() {
+    let dice = TermResult::Dice {
+        multiplier: 3,
+        sides: 6,
+        rolls: vec![4, 1, 6],
+    };
+    assert_eq!(format!("{dice}"), "3d6[4, 1, 6]");
+    assert_eq!(format!("{}", TermResult::Modifier(5)), "+5");
+    assert_eq!(format!("{}", TermResult::Modifier(-6)), "-6");
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -112,7 +112,8 @@ fn roll_dice_produces_roll_for_valid_expression() {
     let r = roll_dice(s);
     let r = r.unwrap();
 
-    assert_eq!(r.drex, "2d6+6+4d10".to_string());
+    // drex now preserves the original expression (C12), not a stripped form.
+    assert_eq!(r.drex, "2d6 + 6 + 4d10".to_string());
     assert_eq!(r.values.len(), 3);
     assert_eq!(r.values[0].1.len(), 2);
     assert_eq!(r.values[1].1.len(), 1);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -52,22 +52,23 @@ fn die_roll_term_parsed() {
         assert_eq!(m, 3);
         assert_eq!(s, 6);
     } else {
-        assert!(false);
+        panic!("expected a DieRoll term");
     }
 
     if let DieRollTerm::Modifier(n) = mfy {
         assert_eq!(n, 7);
     } else {
-        assert!(false);
+        panic!("expected a Modifier term");
     }
 }
 
 #[test]
 fn die_roll_term_calculated() {
-    let dt = DieRollTerm::parse("6d1").unwrap().evaluate();
-    let nt = DieRollTerm::parse("-4d1").unwrap().evaluate();
-    let pm = DieRollTerm::parse("+7").unwrap().evaluate();
-    let nm = DieRollTerm::parse("-7").unwrap().evaluate();
+    let mut rng = rand::rng();
+    let dt = DieRollTerm::parse("6d1").unwrap().evaluate(&mut rng);
+    let nt = DieRollTerm::parse("-4d1").unwrap().evaluate(&mut rng);
+    let pm = DieRollTerm::parse("+7").unwrap().evaluate(&mut rng);
+    let nm = DieRollTerm::parse("-7").unwrap().evaluate(&mut rng);
 
     let dtr = DieRollTerm::calculate(&dt);
     assert_eq!(dtr, 6);
@@ -85,7 +86,7 @@ fn die_roll_term_calculated() {
 #[test]
 fn die_roll_term_evaluated() {
     let drt = DieRollTerm::parse("3d1").unwrap();
-    let v = drt.evaluate();
+    let v = drt.evaluate(&mut rand::rng());
 
     assert_eq!(v.1.len(), 3);
     assert_eq!(v.1[0], 1);
@@ -97,8 +98,9 @@ fn die_roll_term_evaluated() {
 fn die_roll_term_modifier_evaluated() {
     let mfy = DieRollTerm::parse("+7").unwrap();
     let mfy2 = DieRollTerm::parse("-7").unwrap();
-    let v1 = mfy.evaluate();
-    let v2 = mfy2.evaluate();
+    let mut rng = rand::rng();
+    let v1 = mfy.evaluate(&mut rng);
+    let v2 = mfy2.evaluate(&mut rng);
 
     assert_eq!(v1.1.len(), 1);
     assert_eq!(v2.1.len(), 1);
@@ -133,12 +135,7 @@ fn roll_dice_produces_roll_for_valid_expression() {
 #[test]
 fn roll_dice_produces_error_for_invalid_expression() {
     let s = "two plus two equals CHICKEN!";
-    let r = roll_dice(s);
-
-    match r {
-        Ok(_) => assert!(false),
-        Err(_) => assert!(true),
-    }
+    assert!(roll_dice(s).is_err());
 }
 
 #[test]
@@ -154,18 +151,13 @@ fn result_range_roll_produces_result_in_range() {
 
 #[test]
 fn roll_range_min_max_switched() {
-    let r = roll_range(12, 1);
-
-    match r {
-        Ok(_) => assert!(false),
-        Err(_) => assert!(true),
-    }
+    assert!(roll_range(12, 1).is_err());
 }
 
 #[test]
 fn iterator_yields_new_results() {
     let r = roll_dice("3d6");
-    let v: Vec<Roll> = r.unwrap().into_iter().take(6).collect();
+    let v: Vec<Roll> = r.unwrap().rolls().take(6).collect();
 
     assert_eq!(v.len(), 6);
     assert!(v[0].total >= 3 && v[0].total <= 18);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,6 @@
-use Roll;
-use DieRollTerm;
-use {roll_dice, roll_range, parse_die_roll_terms};
+use crate::Roll;
+use crate::DieRollTerm;
+use crate::{roll_dice, roll_range, parse_die_roll_terms};
 
 #[test]
 fn die_roll_expression_parsed() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -9,7 +9,7 @@ fn die_roll_expression_parsed() {
     let nd = "-4d10+5".to_string();
     let mf = "50+2d8-1d4".to_string();
 
-    let pv = parse_die_roll_terms(&pd);
+    let pv = parse_die_roll_terms(&pd).unwrap();
     if let DieRollTerm::DieRoll { multiplier: m, sides: s } = pv[0] {
         assert_eq!(m, 3);
         assert_eq!(s, 12);
@@ -18,7 +18,7 @@ fn die_roll_expression_parsed() {
         assert_eq!(n, 4);
     }
 
-    let nv = parse_die_roll_terms(&nd);
+    let nv = parse_die_roll_terms(&nd).unwrap();
     if let DieRollTerm::DieRoll { multiplier: m, sides: s } = nv[0] {
         assert_eq!(m, -4);
         assert_eq!(s, 10);
@@ -27,7 +27,7 @@ fn die_roll_expression_parsed() {
         assert_eq!(n, 5);
     }
 
-    let mv = parse_die_roll_terms(&mf);
+    let mv = parse_die_roll_terms(&mf).unwrap();
     if let DieRollTerm::Modifier(n) = mv[0] {
         assert_eq!(n, 50);
     }
@@ -46,8 +46,8 @@ fn die_roll_expression_parsed() {
 fn die_roll_term_parsed() {
     let drt = "3d6".to_string();
     let mfy = "+7".to_string();
-    let drt = DieRollTerm::parse(&drt);
-    let mfy = DieRollTerm::parse(&mfy);
+    let drt = DieRollTerm::parse(&drt).unwrap();
+    let mfy = DieRollTerm::parse(&mfy).unwrap();
     if let DieRollTerm::DieRoll { multiplier: m, sides: s } = drt {
         assert_eq!(m, 3);
         assert_eq!(s, 6);
@@ -64,27 +64,27 @@ fn die_roll_term_parsed() {
 
 #[test]
 fn die_roll_term_calculated() {
-    let dt = DieRollTerm::parse("6d1").evaluate();
-    let nt = DieRollTerm::parse("-4d1").evaluate();
-    let pm = DieRollTerm::parse("+7").evaluate();
-    let nm = DieRollTerm::parse("-7").evaluate();
+    let dt = DieRollTerm::parse("6d1").unwrap().evaluate();
+    let nt = DieRollTerm::parse("-4d1").unwrap().evaluate();
+    let pm = DieRollTerm::parse("+7").unwrap().evaluate();
+    let nm = DieRollTerm::parse("-7").unwrap().evaluate();
 
-    let dtr = DieRollTerm::calculate(dt);
+    let dtr = DieRollTerm::calculate(&dt);
     assert_eq!(dtr, 6);
 
-    let ntr = DieRollTerm::calculate(nt);
+    let ntr = DieRollTerm::calculate(&nt);
     assert_eq!(ntr, -4);
 
-    let pmr = DieRollTerm::calculate(pm);
+    let pmr = DieRollTerm::calculate(&pm);
     assert_eq!(pmr, 7);
 
-    let nmr = DieRollTerm::calculate(nm);
+    let nmr = DieRollTerm::calculate(&nm);
     assert_eq!(nmr, -7);
 }
 
 #[test]
 fn die_roll_term_evaluated() {
-    let drt = DieRollTerm::parse("3d1");
+    let drt = DieRollTerm::parse("3d1").unwrap();
     let v = drt.evaluate();
 
     assert_eq!(v.1.len(), 3);
@@ -95,8 +95,8 @@ fn die_roll_term_evaluated() {
 
 #[test]
 fn die_roll_term_modifier_evaluated() {
-    let mfy = DieRollTerm::parse("+7");
-    let mfy2 = DieRollTerm::parse("-7");
+    let mfy = DieRollTerm::parse("+7").unwrap();
+    let mfy2 = DieRollTerm::parse("-7").unwrap();
     let v1 = mfy.evaluate();
     let v2 = mfy2.evaluate();
 
@@ -172,9 +172,9 @@ fn iterator_yields_new_results() {
 
 #[test]
 fn die_roll_term_displays_properly() {
-    let drt = DieRollTerm::parse("3d6");
-    let pm = DieRollTerm::parse("5");
-    let nm = DieRollTerm::parse("-6");
+    let drt = DieRollTerm::parse("3d6").unwrap();
+    let pm = DieRollTerm::parse("5").unwrap();
+    let nm = DieRollTerm::parse("-6").unwrap();
 
     let out = format!("{}", drt);
     assert_eq!(out, "3d6");

--- a/tests/characterization.rs
+++ b/tests/characterization.rs
@@ -136,10 +136,12 @@ fn c6_min_multiplier_abs_panics() {
 }
 
 #[test]
-#[should_panic]
-fn c7_roll_range_max_overflow_panics() {
-    // `max + 1` overflows i32 when max == i32::MAX.
-    let _ = roll_range(0, i32::MAX);
+fn c7_roll_range_max_no_longer_overflows() {
+    // FIXED in Phase 3: migrating `gen_range(min, max + 1)` to the idiomatic
+    // `random_range(min..=max)` removes the `max + 1` overflow. roll_range now
+    // samples the full i32 range without panicking.
+    let v = roll_range(0, i32::MAX).unwrap();
+    assert!(v >= 0, "got {}", v);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/characterization.rs
+++ b/tests/characterization.rs
@@ -39,10 +39,10 @@ fn preserve_deterministic_one_sided_dice() {
 #[test]
 fn preserve_values_structure() {
     let r = roll_dice("2d6 + 6 + 4d10").unwrap();
-    assert_eq!(r.values.len(), 3);
-    assert_eq!(r.values[0].1.len(), 2); // two d6 rolls
-    assert_eq!(r.values[1].1.len(), 1); // single modifier value
-    assert_eq!(r.values[2].1.len(), 4); // four d10 rolls
+    assert_eq!(r.terms.len(), 3);
+    assert_eq!(r.terms[0].rolls().len(), 2); // two d6 rolls
+    assert_eq!(r.terms[1].rolls().len(), 0); // a modifier has no rolls
+    assert_eq!(r.terms[2].rolls().len(), 4); // four d10 rolls
 }
 
 #[test]
@@ -100,7 +100,7 @@ fn c1_large_multiplier_now_supported() {
     // FIXED (Phase 4): multiplier widened i8 -> i32 with a MAX_DICE cap.
     // "128d6" now rolls 128 dice instead of panicking on i8 overflow.
     let r = roll_dice("128d6").unwrap();
-    assert_eq!(r.values[0].1.len(), 128);
+    assert_eq!(r.terms[0].rolls().len(), 128);
     assert!(r.total >= 128 && r.total <= 768, "got {}", r.total);
 }
 
@@ -137,7 +137,7 @@ fn c6_min_multiplier_now_supported() {
     // FIXED (Phase 4): `multiplier.unsigned_abs()` replaces the panicking i8 abs;
     // "-128d6" rolls 128 dice and subtracts them.
     let r = roll_dice("-128d6").unwrap();
-    assert_eq!(r.values[0].1.len(), 128);
+    assert_eq!(r.terms[0].rolls().len(), 128);
     assert!(r.total >= -768 && r.total <= -128, "got {}", r.total);
 }
 
@@ -167,7 +167,7 @@ fn c8_whitespace_no_longer_merges_tokens() {
     );
     // The well-formed version still works and preserves the original drex (C12).
     let r = roll_dice("2d6 + 5").unwrap();
-    assert_eq!(r.values.len(), 2);
+    assert_eq!(r.terms.len(), 2);
     assert_eq!(r.drex, "2d6 + 5");
 }
 
@@ -191,8 +191,8 @@ fn c11_d6_shorthand_now_rolls_one_die() {
     // FIXED (Phase 5): "d6" (shorthand for 1d6) rolls one 6-sided die (1..=6)
     // instead of being misread as the constant +6.
     let r = roll_dice("d6").unwrap();
-    assert_eq!(r.values.len(), 1);
-    assert_eq!(r.values[0].1.len(), 1, "one die rolled");
+    assert_eq!(r.terms.len(), 1);
+    assert_eq!(r.terms[0].rolls().len(), 1, "one die rolled");
     assert!(r.total >= 1 && r.total <= 6, "got {}", r.total);
 }
 

--- a/tests/characterization.rs
+++ b/tests/characterization.rs
@@ -88,51 +88,55 @@ fn preserve_non_numeric_garbage_errors() {
 }
 
 // ---------------------------------------------------------------------------
-// GROUP 2 — PANICS that SHOULD become `Err` (defects C1-C7).
-// Each is pinned with `#[should_panic]`. Post-fix, these become
-// `assert!(roll_dice(...).is_err())` style tests.
+// GROUP 2 — formerly PANICS (defects C1-C7), now FIXED in Phases 3-4.
+// Inputs that used to abort the thread now either roll correctly (large values
+// are supported up to documented caps) or return a clean `Err`.
 // ---------------------------------------------------------------------------
 
 #[test]
-#[should_panic]
-fn c1_multiplier_overflow_panics() {
-    // multiplier: i8 (max 127). Should instead be a graceful error or supported.
-    let _ = roll_dice("128d6");
+fn c1_large_multiplier_now_supported() {
+    // FIXED (Phase 4): multiplier widened i8 -> i32 with a MAX_DICE cap.
+    // "128d6" now rolls 128 dice instead of panicking on i8 overflow.
+    let r = roll_dice("128d6").unwrap();
+    assert_eq!(r.values[0].1.len(), 128);
+    assert!(r.total >= 128 && r.total <= 768, "got {}", r.total);
 }
 
 #[test]
-#[should_panic]
-fn c2_modifier_overflow_panics() {
-    // Modifier(i8) (max 127). "+500" should not abort the thread.
-    let _ = roll_dice("+500");
+fn c2_large_modifier_now_supported() {
+    // FIXED (Phase 4): Modifier widened i8 -> i32 with a MAX_MODIFIER cap.
+    let r = roll_dice("+500").unwrap();
+    assert_eq!(r.total, 500);
 }
 
 #[test]
-#[should_panic]
-fn c3_sides_over_255_panics() {
-    // sides: u8 parse overflow. "1d256" should roll a 256-sided die or error.
-    let _ = roll_dice("1d256");
+fn c3_sides_over_255_now_supported() {
+    // FIXED (Phase 4): sides widened u8 -> u32. "1d256" rolls a 256-sided die.
+    let r = roll_dice("1d256").unwrap();
+    assert!(r.total >= 1 && r.total <= 256, "got {}", r.total);
 }
 
 #[test]
-#[should_panic]
-fn c4_sides_128_to_255_panics() {
-    // sides parses as u8=200 then `200 as i8` wraps to -56 => empty gen_range.
-    let _ = roll_dice("1d200");
+fn c4_sides_128_to_255_now_supported() {
+    // FIXED (Phase 4): the lossy `sides as i8` cast is gone; sampling is done in
+    // u32, so "1d200" rolls a real 200-sided die.
+    let r = roll_dice("1d200").unwrap();
+    assert!(r.total >= 1 && r.total <= 200, "got {}", r.total);
 }
 
 #[test]
-#[should_panic]
-fn c5_zero_sided_die_panics() {
-    // gen_range(1, 1) is an empty range. A 0-sided die should be a clean error.
-    let _ = roll_dice("1d0");
+fn c5_zero_sided_die_now_errors() {
+    // FIXED (Phase 4): a 0-sided die is a clean error instead of an empty-range panic.
+    assert!(roll_dice("1d0").is_err());
 }
 
 #[test]
-#[should_panic]
-fn c6_min_multiplier_abs_panics() {
-    // (-128i8).abs() overflows. "-128d6" should roll 128 dice (negated).
-    let _ = roll_dice("-128d6");
+fn c6_min_multiplier_now_supported() {
+    // FIXED (Phase 4): `multiplier.unsigned_abs()` replaces the panicking i8 abs;
+    // "-128d6" rolls 128 dice and subtracts them.
+    let r = roll_dice("-128d6").unwrap();
+    assert_eq!(r.values[0].1.len(), 128);
+    assert!(r.total >= -768 && r.total <= -128, "got {}", r.total);
 }
 
 #[test]
@@ -190,4 +194,49 @@ fn c13_leading_plus_dropped_in_signed_pair() {
     // "+-3": the regex grabs "-3" and silently drops the leading '+'.
     let r = roll_dice("+-3").unwrap();
     assert_eq!(r.total, -3);
+}
+
+// ---------------------------------------------------------------------------
+// GROUP 4 — documented caps (Phase 4). Values beyond the supported limits are
+// rejected with a descriptive error instead of panicking or hanging.
+// ---------------------------------------------------------------------------
+
+use d20::D20Error;
+use d20::{MAX_DICE, MAX_SIDES};
+
+#[test]
+fn caps_reject_too_many_sides() {
+    let err = roll_dice(&format!("1d{}", MAX_SIDES as u64 + 1)).unwrap_err();
+    assert!(matches!(err, D20Error::SidesTooLarge { .. }), "got {err:?}");
+}
+
+#[test]
+fn caps_reject_too_many_dice() {
+    let err = roll_dice(&format!("{}d6", MAX_DICE as u64 + 1)).unwrap_err();
+    assert!(matches!(err, D20Error::DiceCountTooLarge { .. }), "got {err:?}");
+}
+
+#[test]
+fn caps_reject_unparseable_huge_number() {
+    // A digit run too large for even a 64-bit integer is a clean InvalidTerm,
+    // not a panic.
+    let err = roll_dice("1d999999999999999999999999").unwrap_err();
+    assert!(matches!(err, D20Error::InvalidTerm(_)), "got {err:?}");
+}
+
+#[test]
+fn caps_zero_sided_die_is_specific_error() {
+    assert_eq!(roll_dice("1d0").unwrap_err(), D20Error::ZeroSidedDie);
+}
+
+#[test]
+fn caps_no_input_panics_across_extreme_values() {
+    // Sweep a range of hostile inputs; every one must return Ok or Err, never panic.
+    let inputs = [
+        "0d6", "1d1", "1000000d1000000", "-1000000d20", "+1000000", "-1000000",
+        "1d1000001", "1000001d6", "999999999999d6", "1d0", "",
+    ];
+    for inp in inputs {
+        let _ = roll_dice(inp); // must not panic
+    }
 }

--- a/tests/characterization.rs
+++ b/tests/characterization.rs
@@ -4,12 +4,11 @@
 //! start of the modernization work (edition 2015, rand 0.3, regex 0.2). They are
 //! intentionally split into three groups:
 //!
-//!   1. PRESERVE  — correct behavior that the modernization MUST keep.
-//!   2. PANICS    — inputs that currently `panic!` but SHOULD return `Err`
-//!                  (defects C1-C7 from the review). Pinned with `#[should_panic]`.
-//!   3. WRONG-OK  — inputs that currently return a confidently-wrong `Ok`
-//!                  (defects C8-C13). Pinned by asserting the *current wrong*
-//!                  output, with a comment describing the intended fix.
+//! 1. PRESERVE — correct behavior that the modernization MUST keep.
+//! 2. PANICS — inputs that originally `panic!`'d but should return `Err`
+//!    (defects C1-C7 from the review).
+//! 3. WRONG-OK — inputs that originally returned a confidently-wrong `Ok`
+//!    (defects C8-C13).
 //!
 //! As each fix lands in a later phase, the corresponding test here is rewritten
 //! from "documents the bug" to "asserts the fix", so the diff proves the change.
@@ -58,7 +57,7 @@ fn preserve_display_formatting() {
 #[test]
 fn preserve_range_roll_bounds() {
     let v = roll_range(1, 100).unwrap();
-    assert!(v >= 1 && v <= 100, "got {}", v);
+    assert!((1..=100).contains(&v), "got {}", v);
     // Single-value range returns that value.
     assert_eq!(roll_range(3, 3).unwrap(), 3);
 }
@@ -70,10 +69,10 @@ fn preserve_range_rejects_inverted() {
 
 #[test]
 fn preserve_iterator_take_yields_n_rolls() {
-    // The current `IntoIterator` yields an *infinite* re-roll stream; `take(n)`
-    // bounds it. Phase 6 replaces this with a named iterator method, but the
-    // ability to produce N successive rolls must be preserved.
-    let v: Vec<_> = roll_dice("3d6").unwrap().into_iter().take(6).collect();
+    // The infinite re-roll stream is now reached via the explicit `rolls()`
+    // method (Phase 6) rather than a surprising `IntoIterator`; `take(n)` bounds
+    // it. The ability to produce N successive rolls is preserved.
+    let v: Vec<_> = roll_dice("3d6").unwrap().rolls().take(6).collect();
     assert_eq!(v.len(), 6);
     for roll in &v {
         assert!(roll.total >= 3 && roll.total <= 18, "got {}", roll.total);

--- a/tests/characterization.rs
+++ b/tests/characterization.rs
@@ -149,51 +149,60 @@ fn c7_roll_range_max_no_longer_overflows() {
 }
 
 // ---------------------------------------------------------------------------
-// GROUP 3 — WRONG-OK: silently incorrect results (defects C8-C13).
-// These assert the CURRENT (wrong) behavior. Post-fix, they assert the
-// corrected behavior (a different valid roll, or an `Err`).
+// GROUP 3 — formerly WRONG-OK (defects C8-C13), now FIXED in Phase 5 by the
+// validating parser. Silently-wrong results are now either correct rolls or
+// clean errors.
 // ---------------------------------------------------------------------------
 
 #[test]
-fn c8_whitespace_merges_tokens() {
-    // "2d6 5" should be 2d6 + 5. Today `split_whitespace().collect()` fuses it
-    // into "2d65" => a single 65-sided-die term. CURRENT (wrong) behavior:
-    let r = roll_dice("2d6 5").unwrap();
-    assert_eq!(r.values.len(), 1, "merged into one term");
-    assert_eq!(r.drex, "2d65"); // C12: drex holds the mangled string too
-    assert!(r.total >= 2 && r.total <= 130, "rolls a single d65: {}", r.total);
+fn c8_whitespace_no_longer_merges_tokens() {
+    // FIXED (Phase 5): "2d6 5" is ambiguous (missing operator) and is now
+    // rejected instead of being fused into a single 65-sided die.
+    let err = roll_dice("2d6 5").unwrap_err();
+    assert!(matches!(err, d20::D20Error::MissingOperator(_)), "got {err:?}");
+    // The well-formed version still works and preserves the original drex (C12).
+    let r = roll_dice("2d6 + 5").unwrap();
+    assert_eq!(r.values.len(), 2);
+    assert_eq!(r.drex, "2d6 + 5");
 }
 
 #[test]
-fn c9_garbage_with_digit_succeeds() {
-    // "I have 5 apples" should error; today it extracts "5" and returns Ok(5).
-    let r = roll_dice("I have 5 apples").unwrap();
-    assert_eq!(r.total, 5);
+fn c9_garbage_with_digit_now_errors() {
+    // FIXED (Phase 5): the parser must consume the whole input, so embedded
+    // numbers in prose no longer "succeed".
+    assert!(roll_dice("I have 5 apples").is_err());
 }
 
 #[test]
-fn c10_digit_nonsense_succeeds() {
-    // The companion to the GROUP 1 error test: swap the spelled-out "two" for
-    // the digit "2" and the same nonsense now SUCCEEDS. Demonstrates the error
-    // test passes only by accident (no digits), not by real validation.
-    let r = roll_dice("2 plus 2 equals CHICKEN!").unwrap();
-    assert_eq!(r.total, 4);
+fn c10_digit_nonsense_now_errors() {
+    // FIXED (Phase 5): the companion to preserve_non_numeric_garbage_errors.
+    // Swapping "two" for the digit "2" no longer sneaks through; both error now,
+    // so the validation is real rather than accidental.
+    assert!(roll_dice("2 plus 2 equals CHICKEN!").is_err());
 }
 
 #[test]
-fn c11_d6_shorthand_parsed_as_modifier() {
-    // "d6" (common shorthand for 1d6) should roll one 6-sided die (1..=6).
-    // Today the regex needs a leading digit, so it matches only "6" => +6.
+fn c11_d6_shorthand_now_rolls_one_die() {
+    // FIXED (Phase 5): "d6" (shorthand for 1d6) rolls one 6-sided die (1..=6)
+    // instead of being misread as the constant +6.
     let r = roll_dice("d6").unwrap();
     assert_eq!(r.values.len(), 1);
-    assert_eq!(r.total, 6, "treated as constant +6, never rolled");
+    assert_eq!(r.values[0].1.len(), 1, "one die rolled");
+    assert!(r.total >= 1 && r.total <= 6, "got {}", r.total);
 }
 
 #[test]
-fn c13_leading_plus_dropped_in_signed_pair() {
-    // "+-3": the regex grabs "-3" and silently drops the leading '+'.
-    let r = roll_dice("+-3").unwrap();
-    assert_eq!(r.total, -3);
+fn c13_ambiguous_double_sign_now_errors() {
+    // FIXED (Phase 5): "+-3" is ambiguous and is now rejected rather than
+    // silently dropping the leading '+'.
+    assert!(roll_dice("+-3").is_err());
+}
+
+#[test]
+fn c12_drex_preserves_original_expression() {
+    // FIXED (Phase 5/C12): drex stores the original input, not a mangled copy.
+    let r = roll_dice("2d6 + 6 + 4d10").unwrap();
+    assert_eq!(r.drex, "2d6 + 6 + 4d10");
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/characterization.rs
+++ b/tests/characterization.rs
@@ -51,7 +51,10 @@ fn preserve_display_formatting() {
     assert_eq!(format!("{}", roll), "3d1[1, 1, 1]+5 (Total: 8)");
 
     let bigger = roll_dice("3d1 - 2d1 - 4").unwrap();
-    assert_eq!(format!("{}", bigger), "3d1[1, 1, 1]-2d1[1, 1]-4 (Total: -3)");
+    assert_eq!(
+        format!("{}", bigger),
+        "3d1[1, 1, 1]-2d1[1, 1]-4 (Total: -3)"
+    );
 }
 
 #[test]
@@ -158,7 +161,10 @@ fn c8_whitespace_no_longer_merges_tokens() {
     // FIXED (Phase 5): "2d6 5" is ambiguous (missing operator) and is now
     // rejected instead of being fused into a single 65-sided die.
     let err = roll_dice("2d6 5").unwrap_err();
-    assert!(matches!(err, d20::D20Error::MissingOperator(_)), "got {err:?}");
+    assert!(
+        matches!(err, d20::D20Error::MissingOperator(_)),
+        "got {err:?}"
+    );
     // The well-formed version still works and preserves the original drex (C12).
     let r = roll_dice("2d6 + 5").unwrap();
     assert_eq!(r.values.len(), 2);
@@ -221,7 +227,10 @@ fn caps_reject_too_many_sides() {
 #[test]
 fn caps_reject_too_many_dice() {
     let err = roll_dice(&format!("{}d6", MAX_DICE as u64 + 1)).unwrap_err();
-    assert!(matches!(err, D20Error::DiceCountTooLarge { .. }), "got {err:?}");
+    assert!(
+        matches!(err, D20Error::DiceCountTooLarge { .. }),
+        "got {err:?}"
+    );
 }
 
 #[test]
@@ -241,8 +250,17 @@ fn caps_zero_sided_die_is_specific_error() {
 fn caps_no_input_panics_across_extreme_values() {
     // Sweep a range of hostile inputs; every one must return Ok or Err, never panic.
     let inputs = [
-        "0d6", "1d1", "1000000d1000000", "-1000000d20", "+1000000", "-1000000",
-        "1d1000001", "1000001d6", "999999999999d6", "1d0", "",
+        "0d6",
+        "1d1",
+        "1000000d1000000",
+        "-1000000d20",
+        "+1000000",
+        "-1000000",
+        "1d1000001",
+        "1000001d6",
+        "999999999999d6",
+        "1d0",
+        "",
     ];
     for inp in inputs {
         let _ = roll_dice(inp); // must not panic

--- a/tests/characterization.rs
+++ b/tests/characterization.rs
@@ -1,0 +1,196 @@
+//! Characterization tests for the d20 public API.
+//!
+//! These tests pin the **current, observed behavior** of the library as of the
+//! start of the modernization work (edition 2015, rand 0.3, regex 0.2). They are
+//! intentionally split into three groups:
+//!
+//!   1. PRESERVE  — correct behavior that the modernization MUST keep.
+//!   2. PANICS    — inputs that currently `panic!` but SHOULD return `Err`
+//!                  (defects C1-C7 from the review). Pinned with `#[should_panic]`.
+//!   3. WRONG-OK  — inputs that currently return a confidently-wrong `Ok`
+//!                  (defects C8-C13). Pinned by asserting the *current wrong*
+//!                  output, with a comment describing the intended fix.
+//!
+//! As each fix lands in a later phase, the corresponding test here is rewritten
+//! from "documents the bug" to "asserts the fix", so the diff proves the change.
+//!
+//! NOTE: `extern crate d20;` is required under edition 2015 and will be removed
+//! in Phase 2 (edition 2024 bump).
+
+extern crate d20;
+
+use d20::roll_dice;
+use d20::roll_range;
+
+// ---------------------------------------------------------------------------
+// GROUP 1 — PRESERVE: correct behavior that must survive the rewrite.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn preserve_simple_total_in_range() {
+    // 3d6 ranges 3..=18, plus a +4 modifier => 7..=22.
+    let r = roll_dice("3d6 + 4").unwrap();
+    assert!(r.total >= 7 && r.total <= 22, "got {}", r.total);
+}
+
+#[test]
+fn preserve_deterministic_one_sided_dice() {
+    // 1-sided dice always roll 1, so totals are exact and stable.
+    assert_eq!(roll_dice("3d1 + 2d1 + 1").unwrap().total, 6);
+    assert_eq!(roll_dice("1d1-3").unwrap().total, -2);
+    // Negative multiplier negates that term: -3d1 = -3, +2d1 = +2, +1 => 0.
+    assert_eq!(roll_dice("-3d1 + 2d1 + 1").unwrap().total, 0);
+}
+
+#[test]
+fn preserve_values_structure() {
+    let r = roll_dice("2d6 + 6 + 4d10").unwrap();
+    assert_eq!(r.values.len(), 3);
+    assert_eq!(r.values[0].1.len(), 2); // two d6 rolls
+    assert_eq!(r.values[1].1.len(), 1); // single modifier value
+    assert_eq!(r.values[2].1.len(), 4); // four d10 rolls
+}
+
+#[test]
+fn preserve_display_formatting() {
+    let roll = roll_dice("3d1 + 5").unwrap();
+    assert_eq!(format!("{}", roll), "3d1[1, 1, 1]+5 (Total: 8)");
+
+    let bigger = roll_dice("3d1 - 2d1 - 4").unwrap();
+    assert_eq!(format!("{}", bigger), "3d1[1, 1, 1]-2d1[1, 1]-4 (Total: -3)");
+}
+
+#[test]
+fn preserve_range_roll_bounds() {
+    let v = roll_range(1, 100).unwrap();
+    assert!(v >= 1 && v <= 100, "got {}", v);
+    // Single-value range returns that value.
+    assert_eq!(roll_range(3, 3).unwrap(), 3);
+}
+
+#[test]
+fn preserve_range_rejects_inverted() {
+    assert!(roll_range(12, 1).is_err());
+}
+
+#[test]
+fn preserve_iterator_take_yields_n_rolls() {
+    // The current `IntoIterator` yields an *infinite* re-roll stream; `take(n)`
+    // bounds it. Phase 6 replaces this with a named iterator method, but the
+    // ability to produce N successive rolls must be preserved.
+    let v: Vec<_> = roll_dice("3d6").unwrap().into_iter().take(6).collect();
+    assert_eq!(v.len(), 6);
+    for roll in &v {
+        assert!(roll.total >= 3 && roll.total <= 18, "got {}", roll.total);
+    }
+}
+
+#[test]
+fn preserve_non_numeric_garbage_errors() {
+    // Phrases with no digit at all correctly produce an error today, and must
+    // continue to. (Contrast with C9/C10 below, where digits sneak through.)
+    assert!(roll_dice("two plus two equals CHICKEN!").is_err());
+}
+
+// ---------------------------------------------------------------------------
+// GROUP 2 — PANICS that SHOULD become `Err` (defects C1-C7).
+// Each is pinned with `#[should_panic]`. Post-fix, these become
+// `assert!(roll_dice(...).is_err())` style tests.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic]
+fn c1_multiplier_overflow_panics() {
+    // multiplier: i8 (max 127). Should instead be a graceful error or supported.
+    let _ = roll_dice("128d6");
+}
+
+#[test]
+#[should_panic]
+fn c2_modifier_overflow_panics() {
+    // Modifier(i8) (max 127). "+500" should not abort the thread.
+    let _ = roll_dice("+500");
+}
+
+#[test]
+#[should_panic]
+fn c3_sides_over_255_panics() {
+    // sides: u8 parse overflow. "1d256" should roll a 256-sided die or error.
+    let _ = roll_dice("1d256");
+}
+
+#[test]
+#[should_panic]
+fn c4_sides_128_to_255_panics() {
+    // sides parses as u8=200 then `200 as i8` wraps to -56 => empty gen_range.
+    let _ = roll_dice("1d200");
+}
+
+#[test]
+#[should_panic]
+fn c5_zero_sided_die_panics() {
+    // gen_range(1, 1) is an empty range. A 0-sided die should be a clean error.
+    let _ = roll_dice("1d0");
+}
+
+#[test]
+#[should_panic]
+fn c6_min_multiplier_abs_panics() {
+    // (-128i8).abs() overflows. "-128d6" should roll 128 dice (negated).
+    let _ = roll_dice("-128d6");
+}
+
+#[test]
+#[should_panic]
+fn c7_roll_range_max_overflow_panics() {
+    // `max + 1` overflows i32 when max == i32::MAX.
+    let _ = roll_range(0, i32::MAX);
+}
+
+// ---------------------------------------------------------------------------
+// GROUP 3 — WRONG-OK: silently incorrect results (defects C8-C13).
+// These assert the CURRENT (wrong) behavior. Post-fix, they assert the
+// corrected behavior (a different valid roll, or an `Err`).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn c8_whitespace_merges_tokens() {
+    // "2d6 5" should be 2d6 + 5. Today `split_whitespace().collect()` fuses it
+    // into "2d65" => a single 65-sided-die term. CURRENT (wrong) behavior:
+    let r = roll_dice("2d6 5").unwrap();
+    assert_eq!(r.values.len(), 1, "merged into one term");
+    assert_eq!(r.drex, "2d65"); // C12: drex holds the mangled string too
+    assert!(r.total >= 2 && r.total <= 130, "rolls a single d65: {}", r.total);
+}
+
+#[test]
+fn c9_garbage_with_digit_succeeds() {
+    // "I have 5 apples" should error; today it extracts "5" and returns Ok(5).
+    let r = roll_dice("I have 5 apples").unwrap();
+    assert_eq!(r.total, 5);
+}
+
+#[test]
+fn c10_digit_nonsense_succeeds() {
+    // The companion to the GROUP 1 error test: swap the spelled-out "two" for
+    // the digit "2" and the same nonsense now SUCCEEDS. Demonstrates the error
+    // test passes only by accident (no digits), not by real validation.
+    let r = roll_dice("2 plus 2 equals CHICKEN!").unwrap();
+    assert_eq!(r.total, 4);
+}
+
+#[test]
+fn c11_d6_shorthand_parsed_as_modifier() {
+    // "d6" (common shorthand for 1d6) should roll one 6-sided die (1..=6).
+    // Today the regex needs a leading digit, so it matches only "6" => +6.
+    let r = roll_dice("d6").unwrap();
+    assert_eq!(r.values.len(), 1);
+    assert_eq!(r.total, 6, "treated as constant +6, never rolled");
+}
+
+#[test]
+fn c13_leading_plus_dropped_in_signed_pair() {
+    // "+-3": the regex grabs "-3" and silently drops the leading '+'.
+    let r = roll_dice("+-3").unwrap();
+    assert_eq!(r.total, -3);
+}

--- a/tests/characterization.rs
+++ b/tests/characterization.rs
@@ -13,11 +13,6 @@
 //!
 //! As each fix lands in a later phase, the corresponding test here is rewritten
 //! from "documents the bug" to "asserts the fix", so the diff proves the change.
-//!
-//! NOTE: `extern crate d20;` is required under edition 2015 and will be removed
-//! in Phase 2 (edition 2024 bump).
-
-extern crate d20;
 
 use d20::roll_dice;
 use d20::roll_range;

--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -1,0 +1,124 @@
+//! Property-based and fuzz tests for the d20 public API.
+//!
+//! These complement the example-based characterization tests with invariants
+//! that must hold across a large, generated input space:
+//!
+//!   * `never_panics_on_arbitrary_input` — the headline robustness guarantee:
+//!     no input string ever panics; every call returns `Ok` or `Err`.
+//!   * `total_is_within_theoretical_bounds` — every successful roll's total lies
+//!     within `[min possible, max possible]` for the generated expression.
+//!   * `same_seed_produces_identical_rolls` — the injected RNG makes rolls fully
+//!     reproducible, and the values stay within bounds.
+
+use proptest::prelude::*;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+/// A term used to build a known-valid expression together with its numeric bounds.
+#[derive(Debug, Clone)]
+enum Term {
+    Die { neg: bool, count: u32, sides: u32 },
+    Modifier(i32),
+}
+
+fn term_strategy() -> impl Strategy<Value = Term> {
+    prop_oneof![
+        (any::<bool>(), 1u32..=20, 1u32..=100).prop_map(|(neg, count, sides)| Term::Die {
+            neg,
+            count,
+            sides
+        }),
+        (-1000i32..=1000).prop_map(Term::Modifier),
+    ]
+}
+
+/// Builds a valid roll expression string alongside the minimum and maximum
+/// totals it can possibly produce. Terms after the first are always joined with
+/// an explicit `+`/`-` operator, as the parser requires.
+fn expr_strategy() -> impl Strategy<Value = (String, i64, i64)> {
+    prop::collection::vec(term_strategy(), 1..6).prop_map(|terms| {
+        let mut expr = String::new();
+        let (mut min, mut max) = (0i64, 0i64);
+
+        for (i, term) in terms.iter().enumerate() {
+            match *term {
+                Term::Die { neg, count, sides } => {
+                    let (c, s) = (count as i64, sides as i64);
+                    if neg {
+                        expr.push_str(if i == 0 { "-" } else { " - " });
+                        min -= c * s;
+                        max -= c;
+                    } else {
+                        if i > 0 {
+                            expr.push_str(" + ");
+                        }
+                        min += c;
+                        max += c * s;
+                    }
+                    expr.push_str(&format!("{count}d{sides}"));
+                }
+                Term::Modifier(m) => {
+                    let mag = (m as i64).abs();
+                    if m < 0 {
+                        expr.push_str(if i == 0 { "-" } else { " - " });
+                        min -= mag;
+                        max -= mag;
+                        expr.push_str(&mag.to_string());
+                    } else {
+                        if i > 0 {
+                            expr.push_str(" + ");
+                        }
+                        min += m as i64;
+                        max += m as i64;
+                        expr.push_str(&m.to_string());
+                    }
+                }
+            }
+        }
+
+        (expr, min, max)
+    })
+}
+
+proptest! {
+    /// The core robustness guarantee: no input — however hostile — may panic.
+    #[test]
+    fn never_panics_on_arbitrary_input(s in any::<String>()) {
+        let _ = d20::roll_dice(&s);
+    }
+
+    /// Every successful roll's total must lie within the expression's bounds.
+    #[test]
+    fn total_is_within_theoretical_bounds((expr, min, max) in expr_strategy()) {
+        let mut rng = StdRng::seed_from_u64(0xD20_D1CE);
+        let roll = d20::roll_dice_with_rng(&expr, &mut rng)
+            .unwrap_or_else(|e| panic!("valid expr {expr:?} failed to parse: {e}"));
+        prop_assert!(
+            roll.total >= min && roll.total <= max,
+            "expr={expr:?} total={} expected within [{min}, {max}]",
+            roll.total,
+        );
+    }
+
+    /// The same seed yields bit-for-bit identical rolls (reproducibility), and a
+    /// fresh seed still respects the bounds.
+    #[test]
+    fn same_seed_produces_identical_rolls((expr, min, max) in expr_strategy(), seed in any::<u64>()) {
+        let a = d20::roll_dice_with_rng(&expr, &mut StdRng::seed_from_u64(seed)).unwrap();
+        let b = d20::roll_dice_with_rng(&expr, &mut StdRng::seed_from_u64(seed)).unwrap();
+        prop_assert_eq!(&a, &b);
+        prop_assert!(a.total >= min && a.total <= max);
+    }
+}
+
+/// A plain (non-proptest) determinism check with a fixed seed, documenting that
+/// `roll_dice_with_rng` is reproducible.
+#[test]
+fn fixed_seed_is_reproducible() {
+    let roll =
+        |seed| d20::roll_dice_with_rng("3d6 + 2d10 - 4", &mut StdRng::seed_from_u64(seed)).unwrap();
+    assert_eq!(roll(7), roll(7));
+    // The roll iterator is also seedable through the same parsed terms.
+    let first = roll(7);
+    assert!(first.total >= (3 + 2 - 4) && first.total <= (18 + 20 - 4));
+}


### PR DESCRIPTION
## Summary

Modernizes this 9-year-old proof-of-concept crate to current idiomatic Rust, updates all dependencies, and—most importantly—closes a class of correctness defects where the library would either **panic** or return a **silently-wrong result**. Bumps `0.1.0 → 0.2.0` (the public API changes).

The work is split into reviewable commits, each self-contained and green.

## Why

Two independent adversarial audits (numeric, and parser/semantic) found that the original library:
- **panicked** on a wide band of plausible input (large counts/sides/modifiers, `1d0`, `-128d6`, `roll_range(_, i32::MAX)`), despite advertising a `Result` API; and
- returned a confidently **wrong `Ok`** for others (`2d6 5` silently became a 65-sided die, `I have 5 apples` rolled a `5`, `d6` was read as the constant `+6`).

Root causes: integer types far narrower than the parser accepted (`i8`/`u8`), and a permissive `find_iter` scan that ignored everything between number-shaped matches.

## What changed

- **Toolchain & deps:** Rust edition 2015 → **2024**; `rand 0.3 → 0.10`, `regex 0.2 → 1`; regex compiled once via `std::sync::LazyLock`.
- **No more panics:** wide integer types with documented caps (`MAX_DICE`/`MAX_SIDES`/`MAX_MODIFIER`); a real `D20Error` enum (via `thiserror`). Every failure mode is now a descriptive error. A fuzz property asserts *no input panics*.
- **Validating parser:** the whole input must parse as a sequence of signed terms; garbage and ambiguous juxtaposition are rejected. Adds `d6` shorthand and uppercase `D`; preserves the original expression in `drex`.
- **Idiomatic API:** the surprising infinite `IntoIterator` is now an explicit `Roll::rolls()`; RNG is injectable (`roll_dice_with_rng`) for deterministic, seeded rolls; modernized `Display`, derives, and loops.
- **Self-describing result type:** `Roll.values: Vec<(DieRollTerm, Vec<i32>)>` → `Roll.terms: Vec<TermResult>` (a `Dice { multiplier, sides, rolls }` / `Modifier(i32)` enum with `subtotal()` / `rolls()`), so modifiers are no longer faked as single-element rolls.

All breaking changes and fixes are catalogued in the new [`CHANGELOG.md`](CHANGELOG.md) under the `0.2.0` entry (Added / Changed / Fixed / Removed), so anyone upgrading from `0.1.0` can see exactly what moved.

## Verification

- **46 tests**: 12 unit + 26 characterization (which pin every original defect and prove each became a clean error or correct result) + 4 doctests + 4 property/fuzz.
- `cargo clippy --all-targets`, `cargo fmt --check`, and `cargo doc` are all clean.

Note: this PR replaces the long-outdated `rand`/`regex` dependency trees, so it may also clear the Dependabot alert currently reported on `master` (worth confirming against the specific advisory).

## Commits

1. Characterization tests pinning baseline behavior
2. Edition 2024
3. `rand`/`regex` bump + `LazyLock` regex
4. Wide types + `D20Error` (fixes the panics)
5. Validating parser (fixes the silently-wrong results)
6. `rolls()` iterator, RNG injection, clippy-clean
7. Property/fuzz tests, rustfmt, v0.2.0
8. Self-describing `TermResult` result type
9. `CHANGELOG.md` with the 0.2.0 entry
