### PR TITLE
Declare MSRV 1.85 and bump to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-06-11
+
+### Added
+- Declared a minimum supported Rust version of `1.85` via `rust-version` in
+  `Cargo.toml`. This is the version required by edition 2024 and `rand 0.10`;
+  declaring it gives users on older toolchains a clear error instead of a
+  cryptic build failure. No code or behavior changes.
+
 ## [0.2.0] - 2026-06-10
 
 Modernization to current idiomatic Rust, dependency updates, and a set of

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "d20"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Dan Nemeth <dan.nemeth@gmail.com>", "Kevin Hoffman <alothien@gmail.com>"]
 description = "A library for rolling dice based on simple expressions"
 license = "MPL-2.0"
@@ -10,6 +10,7 @@ repository = "https://github.com/pholactery/d20"
 readme = "README.md"
 keywords = ["dice", "roll", "game", "random", "dnd"]
 edition = "2024"
+rust-version = "1.85"
 
 
 [dependencies]


### PR DESCRIPTION
## Summary

Declares a minimum supported Rust version of **1.85** and bumps `0.2.0 → 0.2.1`. Documentation/metadata only — no code or behavior changes.

## Why

`0.2.0` moved to edition 2024 and `rand 0.10`, both of which require Rust ≥ 1.85, but the crate never declared it. Without `rust-version`, a user on an older toolchain gets a cryptic compile error instead of a clear *"requires rustc 1.85"* message (and the MSRV-aware resolver can't account for it).

## What changed

- `Cargo.toml`: add `rust-version = "1.85"`, bump `version` to `0.2.1`.
- `CHANGELOG.md`: add a `[0.2.1]` entry.

## How 1.85 was verified

The true MSRV is `max(edition floor, highest declared rust-version in the normal dependency closure)`:

- Edition 2024 fixes a hard floor of **1.85** (nothing below compiles the crate).
- The highest declared `rust-version` across the normal (non-dev) dependency closure is also **1.85**, set by `rand 0.10.1`, `rand_core 0.10.1`, `getrandom 0.4.2`, and `chacha20 0.10.0`. All other deps are lower (`regex` 1.65, `thiserror` 1.68, `syn`/`quote` 1.71, `libc` 1.65, …).

So `max(1.85, 1.85) = 1.85` exactly — no dependency pushes it higher, the edition prevents it going lower. (`proptest`'s transitive `rand 0.9` / `getrandom 0.3` are dev-only and don't affect consumers.)

## Verification

- `cargo build` clean; `cargo metadata` reports `rust_version: 1.85`.
- `cargo publish --dry-run` packages `d20 v0.2.1` successfully.
